### PR TITLE
docs: document OSS contribution governance (ADR 010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   startup (fails closed on missing/mismatched models).
 - **Shared model manifest** — added `visage-models` crate containing the model list and
   verification helpers used by both the CLI and daemon.
+- **OSS contribution governance** — added `SECURITY.md` (private vulnerability reporting
+  via GitHub Security Advisories), branch protection on `main` (required PR + CI + review),
+  `CODEOWNERS`, issue/PR templates, DCO sign-off policy, Dependabot for dependency updates,
+  and documented merge strategy with review timeline commitments. See ADR 010.
 
 ## v0.2.0 — 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Bugs fixed during testing: [DeviceAllow glob](docs/STATUS.md#bugs-found-during-t
 - [Release Status & Known Limitations](docs/STATUS.md)
 - [Architecture](docs/architecture.md)
 - [Threat Model](docs/threat-model.md)
-- [Architecture Decisions](docs/decisions/) ← 9 ADRs covering all implementation and security decisions
+- [Architecture Decisions](docs/decisions/) ← 10 ADRs covering implementation, security, and governance decisions
 
 ## Security
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Visage v0.3 Release Status
 
-**Last updated:** 2026-02-23
+**Last updated:** 2026-02-24
 **Build state:** v0.3.0 shipped. All 6 implementation steps complete + model integrity enforcement. End-to-end tested on Ubuntu 24.04.4 LTS.
 
 ---
@@ -95,6 +95,17 @@ Items marked ✅ have been verified; items marked ⬜ require hardware not avail
    - `visaged` fails closed at startup if models are missing or checksums mismatch
    - `visage setup` refactored to use shared manifest (no duplicated model list)
    - ADR 009 documents rationale, trade-offs, and known limitations
+
+5. ~~OSS contribution governance~~ — **DONE** (2026-02-24)
+   - `SECURITY.md`: private vulnerability reporting via GitHub Security Advisories
+   - Branch protection on `main`: required PR, 1 approval, `test` status check, no force push
+   - `CODEOWNERS`: `@sovren-software` owns all paths; explicit entries for security crates
+   - Issue templates: bug report, hardware report, feature request + config.yml
+   - PR template: type, description, testing, quality gate checklist
+   - `CONTRIBUTING.md`: DCO sign-off policy, merge strategy, review timeline
+   - Dependabot: weekly Cargo + GitHub Actions dependency PRs
+   - LICENSE copyright corrected to Sovren Software
+   - ADR 010 documents rationale, trade-offs, and known limitations
 
 ### High Priority (not blockers but ship before public announcement)
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -1,7 +1,7 @@
 # Visage Strategy
 
 **Status:** Living — reflects committed direction. Updated as versions ship.
-**Last reviewed:** 2026-02-23
+**Last reviewed:** 2026-02-24
 
 ---
 
@@ -80,6 +80,7 @@ encrypted embeddings at rest. The benchmark provides the concrete numbers.
 |------|--------|
 | AUR PKGBUILD | ✅ `packaging/aur/` |
 | NixOS derivation | ✅ `packaging/nix/` — flake wiring pending |
+| OSS contribution governance | ✅ Branch protection, SECURITY.md, templates, CODEOWNERS, DCO (ADR 010) |
 | COPR RPM spec | ⬜ `packaging/rpm/` |
 | Howdy vs Visage benchmark | ⬜ Matched hardware, published methodology |
 | Active liveness detection | ⬜ Blink challenge — proof of concept |
@@ -180,4 +181,5 @@ The PAM module shipped in v0.1.0 will work with v3 without modification. It call
 | [research/v3-vision.md](research/v3-vision.md) | Full v3 architecture — 5 dimensions with concrete implementation paths |
 | [architecture.md](architecture.md) | Component overview, data flow, API surface |
 | [threat-model.md](threat-model.md) | Threat model, trust boundaries, attack mitigations |
-| [marketing/distribution-strategy.md](marketing/distribution-strategy.md) | Distribution priority — why packages precede the public announcement |
+| [SECURITY.md](../SECURITY.md) | Vulnerability reporting policy, component risk table, response timeline |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Contribution guide — scope, PR process, DCO, merge strategy |

--- a/docs/decisions/010-open-source-contribution-governance.md
+++ b/docs/decisions/010-open-source-contribution-governance.md
@@ -1,0 +1,189 @@
+# ADR 010 — Open Source Contribution Governance
+
+**Date:** 2026-02-24
+**Status:** Accepted
+**Deciders:** Sovren Software core team
+
+---
+
+## Context
+
+Visage is a public GitHub repository under `sovren-software/visage`, licensed MIT. Before
+public promotion and community launch (Summer 2026), the project needs infrastructure to:
+
+1. Accept and review external pull requests safely — especially for security-critical
+   crates (`visaged`, `pam-visage`, `visage-core`, `visage-models`) that form the
+   authentication path.
+2. Provide a private disclosure channel for security vulnerabilities — Visage is a PAM
+   module with root-level daemon access; public CVE disclosure without a fix is dangerous.
+3. Define contribution scope boundaries — the Linux community is generous with feature
+   suggestions, and Visage must stay focused on facial authentication.
+4. Establish merge strategy, review expectations, and intellectual property hygiene for
+   contributions.
+
+Without this infrastructure, the first external PR would arrive with no review process,
+no CI enforcement, no scope guidance, and no security disclosure path.
+
+---
+
+## Decision
+
+### 1. Branch Protection on `main`
+
+All changes to `main` must go through a pull request. Direct pushes are blocked.
+
+**Rules enforced:**
+- Require pull request before merging (1 approval minimum)
+- Require `test` status check to pass (fmt + clippy + build + test)
+- Block force pushes
+- Restrict deletions
+- No bypass list (admins use `--admin` flag for exceptional cases only)
+
+**Rationale:** CODEOWNERS is meaningless without required reviews. CI gates are meaningless
+without required status checks. Branch protection is the enforcement layer that gives the
+other tools teeth.
+
+### 2. Security Disclosure via GitHub Private Vulnerability Reporting
+
+Security vulnerabilities are reported through GitHub's built-in Private Vulnerability
+Reporting feature, documented in `SECURITY.md`.
+
+**What we considered:**
+- **Email-only** (e.g. `security@sovren.software`) — simpler but requires email
+  infrastructure, PGP key management, and manual triage.
+- **GitHub Security Advisories** — chosen. Zero infrastructure cost, integrates with
+  GitHub's CVE database, provides private discussion space, and is the path most security
+  researchers already know.
+
+**Response timeline committed:**
+| Stage | Target |
+|-------|--------|
+| Acknowledgment | 48 hours |
+| Initial assessment | 7 days |
+| Fix (critical/high) | 30 days |
+| Coordinated disclosure | After fix ships; 90-day maximum |
+
+### 3. Developer Certificate of Origin (DCO)
+
+Contributors sign off commits with `git commit -s`, certifying the contribution is their
+own work under the project's MIT license.
+
+**What we considered:**
+- **Contributor License Agreement (CLA)** — legal overhead, discourages casual
+  contributors, requires CLA bot infrastructure. Appropriate for dual-licensed or
+  corporate-backed projects; overkill for a single-license MIT project.
+- **DCO** — chosen. Lightweight, well-understood in the Linux kernel and Rust ecosystem,
+  no legal review required, no bot infrastructure. The sign-off line is sufficient for MIT.
+- **Nothing** — risky. Without any IP hygiene, a contributor could later claim their code
+  was submitted without authorization.
+
+**Enforcement:** Currently honor-system with maintainer review. Automated DCO check can be
+added later if contribution volume warrants it.
+
+### 4. Merge Strategy
+
+| Contribution type | Merge method | Rationale |
+|---|---|---|
+| Hardware quirks, documentation | Merge commit | Preserves contributor attribution in history |
+| Bug fixes, features | Squash and merge | Clean linear history on `main` |
+| Multi-crate refactors | Maintainer discretion | Depends on whether intermediate commits are meaningful |
+
+**Rationale:** Squash-by-default keeps `main` history clean for bisection. Merge commits
+for quirks and docs ensure contributors see their name in `git log` — important for a
+project that depends on community hardware testing.
+
+### 5. Code Ownership (CODEOWNERS)
+
+`@sovren-software` is the required reviewer for all paths. Security-critical crates
+(`visaged`, `pam-visage`, `visage-core`, `visage-models`) and system configuration
+(`packaging/debian/`, `systemd/`, `dbus/`, `.github/`) have explicit entries.
+
+**What we considered:**
+- **Individual username** (`@ccross`) — creates a bus factor of 1.
+- **GitHub team** (`@sovren-software/core`) — requires creating and maintaining a team.
+- **Org-level** (`@sovren-software`) — chosen. Scales automatically as team grows.
+  Any org member can review, but at least one must approve.
+
+### 6. Issue and PR Templates
+
+Three issue templates and one PR template standardize contribution quality:
+
+| Template | Purpose |
+|----------|---------|
+| Bug report | Structured: environment, repro steps, expected/actual, logs |
+| Hardware report | Mirrors Adopt-a-Laptop format — device info, test results, discovery output |
+| Feature request | Includes scope-check reminder linking the out-of-scope table |
+| PR template | Type checkbox, description, testing evidence, quality gate checklist |
+
+**Rationale:** The highest-value contributions (hardware quirks) come from users who may
+not be experienced OSS contributors. Templates reduce the back-and-forth from "please add
+your camera VID:PID" to zero.
+
+### 7. Automated Dependency Management (Dependabot)
+
+Dependabot opens weekly PRs for Cargo dependency updates and GitHub Actions version bumps.
+Limits: 5 Cargo PRs/week, 3 Actions PRs/week.
+
+**Rationale:** A PAM authentication module must keep dependencies current. Dependabot
+alerts were already enabled; automated PRs close the loop by making updates reviewable
+and CI-tested before merge.
+
+### 8. Review Timeline Commitments
+
+| PR type | Target review time |
+|---------|-------------------|
+| Hardware quirk | 1–2 business days |
+| Bug fix | 3–5 business days |
+| Packaging / feature | 1–2 weeks |
+
+**Rationale:** Published timelines set contributor expectations and reduce "is anyone
+looking at this?" pings. Hardware quirks are fast-tracked because each one unlocks support
+for an entire laptop model.
+
+---
+
+## Consequences
+
+### Benefits
+
+- **PRs cannot bypass CI or review** — the authentication path is always protected.
+- **Security researchers have a private channel** — no public zero-days.
+- **Contributors know what to expect** — scope, timeline, merge strategy, IP requirements
+  are all documented before the first external PR arrives.
+- **Hardware quirk contributions are frictionless** — template + fast-track review +
+  merge commit attribution.
+- **Dependencies stay current automatically** — Dependabot + required CI = safe updates.
+
+### Drawbacks
+
+- **Single-maintainer bottleneck** — all PRs require `@sovren-software` approval. If the
+  maintainer is unavailable, PRs queue. Mitigated by adding org members as the team grows.
+- **Admin merge override exists** — `gh pr merge --admin` bypasses the 1-approval
+  requirement. Necessary for solo-maintainer bootstrap but should be used sparingly and
+  only for non-security changes.
+- **DCO is not automatically enforced** — a contributor could forget the sign-off line.
+  Maintainer catches this during review. Automated enforcement (e.g. `dco-bot`) can be
+  added when contribution volume justifies it.
+- **No CLA** — MIT license makes this acceptable, but if the project ever needs to
+  relicense, DCO alone may not be sufficient. This is an acceptable trade-off for the
+  current stage.
+
+### Known Limitations
+
+| Limitation | Impact | Mitigation |
+|------------|--------|------------|
+| No automated DCO enforcement | Contributor may forget sign-off | Maintainer review catches it; add bot later |
+| No required CODEOWNERS review | CODEOWNERS suggests but GitHub rulesets don't require specific team review | Org-level review covers all paths |
+| Admin bypass available | Maintainer can skip review for own PRs | Used only for non-security, non-code changes |
+| Single approval required | One compromised reviewer could approve malicious code | Acceptable at current team size; raise to 2 when team grows |
+
+---
+
+## References
+
+- [SECURITY.md](../../SECURITY.md) — vulnerability reporting policy
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — contributor guide with scope, PR process, DCO
+- [.github/CODEOWNERS](../../.github/CODEOWNERS) — ownership map
+- [.github/pull_request_template.md](../../.github/pull_request_template.md) — PR template
+- [.github/dependabot.yml](../../.github/dependabot.yml) — dependency automation config
+- [Developer Certificate of Origin](https://developercertificate.org/)


### PR DESCRIPTION
## Type

- [x] Documentation

## Description

Documents the OSS contribution governance infrastructure shipped in v0.3.0.

**New:**
- **ADR 010** — rationale and trade-offs for all governance decisions: DCO over CLA, branch protection rules, merge strategy (squash vs merge), CODEOWNERS at org level, GitHub Private Vulnerability Reporting over email, issue/PR templates, Dependabot, review timeline commitments. Includes known limitations table.

**Updated:**
- **STATUS.md** — adds item 5 to blockers section: OSS governance (DONE), with full list of infrastructure shipped
- **STRATEGY.md** — adds OSS governance to public launch checklist (✅), fixes broken link to deleted `distribution-strategy.md` (moved to vault), replaces with SECURITY.md and CONTRIBUTING.md links
- **CHANGELOG.md** — adds governance entry under v0.3.0
- **README.md** — bumps ADR count from 9 to 10

## Testing

Documentation only — no code changes. Verified all cross-references resolve.

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] No new warnings introduced
- [x] I have read CONTRIBUTING.md