### PR TITLE
docs: record v0.3.0 local validation results

### DIFF
--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -423,6 +423,29 @@ See [contrib/hw/README.md](../contrib/hw/README.md).
 
 ---
 
+### Daemon still running old version after package upgrade
+
+`apt install` upgrades the package files on disk but does **not** restart the daemon.
+The old process remains in memory until you restart it:
+
+```bash
+sudo systemctl restart visaged
+```
+
+After restart, verify with `visage status` — the version field should match the
+installed package (`dpkg -l visage`).
+
+**Note:** If the old enrollment was created before AES-256-GCM encryption was added,
+the daemon reads it transparently via the legacy plaintext path. Re-enrolling is
+recommended to store the embedding in encrypted form:
+
+```bash
+sudo visage remove <model-id> --user <username>
+sudo visage enroll --label default --user <username>
+```
+
+---
+
 ### Face auth broken after software update
 
 If a package update caused PAM issues:


### PR DESCRIPTION
## Type

- [x] Documentation

## Description

Records the results of the full v0.3.0 local validation run (upgrade from v0.1.0).

**STATUS.md:**
- Build state updated to reflect validated upgrade path (v0.1.0 → v0.3.0)
- Acceptance test results updated with v0.3.0 similarity scores (0.97 CLI, 0.91 PAM)
- Added D-Bus access control tests: non-root list rejected, cross-user remove rejected
- Added **v0.3.0 Upgrade Path** section: legacy plaintext migration, encryption key generation, model integrity check, enhanced status fields, discover output, PAM re-verification

**operations-guide.md:**
- Added troubleshooting entry: daemon still running old version after package upgrade
- Includes restart instructions and legacy enrollment re-enrollment guidance

## Testing

Documentation only — no code changes.

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] No new warnings introduced
- [x] I have read CONTRIBUTING.md