### PR TITLE
feat: proper NixOS and Arch Linux packaging integrations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Visage — Linux face authentication via PAM";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      # NixOS module — works on all architectures
+      nixosModule = import ./packaging/nix/module.nix;
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        visage = pkgs.callPackage ./packaging/nix/default.nix { };
+      in
+      {
+        packages = {
+          default = visage;
+          visage = visage;
+        };
+
+        # nix develop — drop into a shell with all build dependencies
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ visage ];
+          packages = with pkgs; [
+            rust-analyzer
+            cargo-deb
+            cargo-watch
+          ];
+        };
+      }
+    ) // {
+      # NixOS module export
+      nixosModules.default = nixosModule;
+      nixosModules.visage = nixosModule;
+    };
+}

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,5 +1,5 @@
 # Maintainer: Sovren Software <hello@sovren.software>
-# Contributor: https://github.com/sovren-software/visage
+# https://github.com/sovren-software/visage
 
 pkgname=visage
 pkgver=0.3.0
@@ -8,24 +8,36 @@ pkgdesc="Linux face authentication via PAM — persistent daemon, IR camera supp
 arch=('x86_64')
 url="https://github.com/sovren-software/visage"
 license=('MIT')
-depends=('pam' 'dbus')
+depends=('pam' 'dbus' 'systemd')
 makedepends=('rust' 'cargo' 'pkg-config')
+provides=('visage')
+conflicts=('visage')
 install="$pkgname.install"
+# Preserve user data and face database across upgrades
+backup=('var/lib/visage/faces.db')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/sovren-software/visage/archive/refs/tags/v$pkgver.tar.gz")
-# Update sha256sum after computing: sha256sum visage-0.3.0.tar.gz
+# TODO: compute real sha256sum at release time: sha256sum visage-0.3.0.tar.gz
 sha256sums=('SKIP')
 
 build() {
     cd "$pkgname-$pkgver"
+    export CARGO_TARGET_DIR=target
     cargo build --release --workspace
+}
+
+check() {
+    cd "$pkgname-$pkgver"
+    export CARGO_TARGET_DIR=target
+    # Unit tests only — integration tests require a running daemon and camera
+    cargo test --workspace --lib
 }
 
 package() {
     cd "$pkgname-$pkgver"
 
     # Binaries
-    install -Dm755 target/release/visaged        "$pkgdir/usr/bin/visaged"
-    install -Dm755 target/release/visage         "$pkgdir/usr/bin/visage"
+    install -Dm755 target/release/visaged "$pkgdir/usr/bin/visaged"
+    install -Dm755 target/release/visage  "$pkgdir/usr/bin/visage"
 
     # PAM module
     install -Dm644 target/release/libpam_visage.so \
@@ -41,10 +53,10 @@ package() {
     install -Dm644 packaging/systemd/visage-resume.service \
         "$pkgdir/usr/lib/systemd/system/visage-resume.service"
 
-    # Model directory (empty — models downloaded at runtime via `visage setup`)
+    # State directory (empty — models downloaded at runtime via `visage setup`)
     install -dm700 "$pkgdir/var/lib/visage/models"
 
     # License and docs
-    install -Dm644 LICENSE       "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-    install -Dm644 README.md     "$pkgdir/usr/share/doc/$pkgname/README.md"
+    install -Dm644 LICENSE   "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
 }

--- a/packaging/aur/visage.install
+++ b/packaging/aur/visage.install
@@ -1,30 +1,68 @@
 post_install() {
-    echo ""
-    echo ">>> Visage installed. Run the following to complete setup:"
-    echo ""
-    echo "    sudo visage setup          # download ONNX models (~182 MB)"
-    echo "    visage enroll              # enroll your face"
-    echo ""
-    echo ">>> PAM configuration (Arch Linux):"
-    echo "    Add the following line BEFORE 'auth required pam_unix.so' in"
-    echo "    /etc/pam.d/system-auth (or the specific service you want, e.g. sudo):"
-    echo ""
-    echo "        auth sufficient pam_visage.so"
-    echo ""
-    echo "    On failure or daemon unavailability, Visage passes through to password."
-    echo ""
     systemctl daemon-reload || true
     systemctl enable --now visaged.service 2>/dev/null || true
     systemctl enable visage-resume.service 2>/dev/null || true
+
+    echo ""
+    echo "==> Visage installed. Complete setup with:"
+    echo ""
+    echo "  1. Download ONNX models (~182 MB):"
+    echo "     sudo visage setup"
+    echo ""
+    echo "  2. Enroll your face:"
+    echo "     sudo visage enroll --label default"
+    echo ""
+    echo "  3. Configure PAM (enables face auth for sudo, login, etc.):"
+    echo "     Add this line BEFORE 'auth required pam_unix.so' in"
+    echo "     /etc/pam.d/system-auth:"
+    echo ""
+    echo "       auth  [success=end default=ignore]  pam_visage.so"
+    echo ""
+    echo "     Or for sudo only, add the same line to /etc/pam.d/sudo."
+    echo "     On failure or daemon unavailability, password is used as fallback."
+    echo ""
+    echo "  4. Test:"
+    echo "     visage verify                # manual face check"
+    echo "     sudo echo 'face auth works'  # PAM integration test"
+    echo ""
+    echo "  See: https://github.com/sovren-software/visage/blob/main/docs/operations-guide.md"
+    echo ""
+
+    if [ ! -f /var/lib/visage/models/det_10g.onnx ]; then
+        echo "==> WARNING: ONNX models not found. Run 'sudo visage setup' first."
+    fi
 }
 
 post_upgrade() {
     systemctl daemon-reload || true
     systemctl restart visaged.service 2>/dev/null || true
+
+    echo ""
+    echo "==> Visage upgraded to $1."
+    echo "    Daemon restarted. Verify with: visage status"
+    echo ""
+    echo "    If upgrading from a pre-0.3.0 version, re-enrollment is recommended"
+    echo "    to store embeddings in encrypted form:"
+    echo "      sudo visage remove <model-id> --user \$USER"
+    echo "      sudo visage enroll --label default"
+    echo ""
 }
 
 pre_remove() {
     systemctl stop    visaged.service 2>/dev/null || true
     systemctl disable visaged.service 2>/dev/null || true
     systemctl disable visage-resume.service 2>/dev/null || true
+}
+
+post_remove() {
+    systemctl daemon-reload || true
+
+    echo ""
+    echo "==> Visage removed."
+    echo "    Remember to remove the pam_visage.so line from /etc/pam.d/system-auth"
+    echo "    (or /etc/pam.d/sudo) if you added it manually."
+    echo ""
+    echo "    Face database and models remain in /var/lib/visage/."
+    echo "    To remove all data: sudo rm -rf /var/lib/visage"
+    echo ""
 }

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -1,7 +1,11 @@
 # Visage — NixOS package derivation
 #
-# Build from repo:
-#   nix build .#visage   (once wired into flake.nix)
+# Usage (standalone):
+#   nix build .#visage
+#
+# Usage (NixOS module — recommended):
+#   imports = [ visage.nixosModules.default ];
+#   services.visage.enable = true;
 #
 # For nixpkgs submission, replace src/cargoLock with fetchFromGitHub + cargoHash.
 
@@ -10,6 +14,7 @@
 , pkg-config
 , pam
 , dbus
+, substituteAll ? null
 }:
 
 rustPlatform.buildRustPackage {
@@ -23,6 +28,14 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ pam dbus ];
 
+  # cargo test runs unit tests; integration tests require a camera + daemon
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    cargo test --workspace --lib
+    runHook postCheck
+  '';
+
   postInstall = ''
     # PAM module (cdylib — not installed by cargo install)
     install -Dm755 target/release/libpam_visage.so \
@@ -32,11 +45,16 @@ rustPlatform.buildRustPackage {
     install -Dm644 packaging/dbus/org.freedesktop.Visage1.conf \
       $out/share/dbus-1/system.d/org.freedesktop.Visage1.conf
 
-    # systemd units
+    # systemd units — patch ExecStart to reference the Nix store path
     install -Dm644 packaging/systemd/visaged.service \
       $out/lib/systemd/system/visaged.service
+    substituteInPlace $out/lib/systemd/system/visaged.service \
+      --replace-fail "/usr/bin/visaged" "$out/bin/visaged"
+
     install -Dm644 packaging/systemd/visage-resume.service \
       $out/lib/systemd/system/visage-resume.service
+    substituteInPlace $out/lib/systemd/system/visage-resume.service \
+      --replace-fail "/usr/bin/systemctl" "systemctl"
   '';
 
   meta = with lib; {

--- a/packaging/nix/module.nix
+++ b/packaging/nix/module.nix
@@ -1,0 +1,175 @@
+# Visage — NixOS module
+#
+# Usage in your NixOS configuration:
+#
+#   imports = [ visage.nixosModules.default ];
+#
+#   services.visage = {
+#     enable = true;
+#     # modelDir = "/var/lib/visage/models";  # default
+#     # logLevel = "visaged=info";             # default
+#   };
+#
+# This module:
+#   - Installs visage, visaged, and the PAM module
+#   - Creates and manages /var/lib/visage with correct permissions
+#   - Registers the D-Bus system bus policy
+#   - Enables the visaged systemd service (hardened)
+#   - Enables the suspend/resume restart service
+#   - Configures PAM for face authentication (before password, with fallback)
+
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.visage;
+  visagePkg = pkgs.callPackage ./default.nix { };
+in
+{
+  options.services.visage = {
+    enable = lib.mkEnableOption "Visage face authentication daemon";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = visagePkg;
+      defaultText = lib.literalExpression "pkgs.visage";
+      description = "The Visage package to use.";
+    };
+
+    modelDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/visage/models";
+      description = "Directory containing ONNX face detection and recognition models.";
+    };
+
+    dbPath = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/visage/faces.db";
+      description = "Path to the SQLite face embedding database.";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.str;
+      default = "visaged=info";
+      description = "RUST_LOG filter string for the daemon.";
+    };
+
+    camera = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/dev/video2";
+      description = ''
+        Camera device path. When null, the daemon auto-detects the first
+        available V4L2 capture device.
+      '';
+    };
+
+    similarityThreshold = lib.mkOption {
+      type = lib.types.nullOr lib.types.float;
+      default = null;
+      example = 0.45;
+      description = ''
+        Cosine similarity threshold for face matching. Higher values are
+        stricter. When null, the daemon uses its compiled default (0.45).
+      '';
+    };
+
+    pam.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to enable Visage PAM integration. When enabled, face
+        authentication is tried before password for sudo, login, and
+        screen lock. Password is always available as fallback.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Make CLI available system-wide
+    environment.systemPackages = [ cfg.package ];
+
+    # D-Bus system bus policy — allows daemon to own the bus name,
+    # restricts mutation methods to root, allows verify/status for all users
+    services.dbus.packages = [ cfg.package ];
+
+    # State directory
+    systemd.tmpfiles.rules = [
+      "d /var/lib/visage 0700 root root -"
+      "d ${cfg.modelDir} 0700 root root -"
+    ];
+
+    # Main daemon service
+    systemd.services.visaged = {
+      description = "Visage biometric authentication daemon";
+      after = [ "dbus.service" ];
+      requires = [ "dbus.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        VISAGE_MODEL_DIR = toString cfg.modelDir;
+        VISAGE_DB_PATH = toString cfg.dbPath;
+        RUST_LOG = cfg.logLevel;
+      } // lib.optionalAttrs (cfg.camera != null) {
+        VISAGE_CAMERA = cfg.camera;
+      } // lib.optionalAttrs (cfg.similarityThreshold != null) {
+        VISAGE_SIMILARITY_THRESHOLD = toString cfg.similarityThreshold;
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/visaged";
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        # Hardening (mirrors packaging/systemd/visaged.service)
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        DeviceAllow = [ "char-video4linux rw" ];
+        ReadWritePaths = [ "/var/lib/visage" ];
+        CapabilityBoundingSet = "";
+        SystemCallArchitectures = "native";
+        MemoryDenyWriteExecute = false;
+      };
+    };
+
+    # Restart daemon after resume from suspend/hibernate
+    systemd.services.visage-resume = {
+      description = "Restart Visage daemon after resume from suspend";
+      after = [
+        "suspend.target"
+        "hibernate.target"
+        "hybrid-sleep.target"
+        "suspend-then-hibernate.target"
+      ];
+      wantedBy = [
+        "suspend.target"
+        "hibernate.target"
+        "hybrid-sleep.target"
+        "suspend-then-hibernate.target"
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.systemd}/bin/systemctl restart visaged.service";
+      };
+    };
+
+    # PAM integration — face auth before password, password fallback
+    security.pam.services = lib.mkIf cfg.pam.enable {
+      sudo.rules.auth.visage = {
+        order = 900;
+        control = "[success=end default=ignore]";
+        modulePath = "${cfg.package}/lib/security/pam_visage.so";
+      };
+      login.rules.auth.visage = {
+        order = 900;
+        control = "[success=end default=ignore]";
+        modulePath = "${cfg.package}/lib/security/pam_visage.so";
+      };
+      # Screen lockers (swaylock, hyprlock, etc.) use their own PAM service.
+      # Users can add more via:
+      #   security.pam.services.<name>.rules.auth.visage = { ... };
+    };
+  };
+}


### PR DESCRIPTION
## Type

- [x] Feature: Distribution packaging

## Description

Properly implements the NixOS and Arch Linux packaging that previously existed as untested scaffolds.

### NixOS

- **`packaging/nix/default.nix`** — patches systemd unit `ExecStart` paths for the Nix store (`$out/bin/visaged`), adds `doCheck` phase running `cargo test --workspace --lib`
- **`packaging/nix/module.nix`** (new) — full NixOS module with declarative options:
  - `services.visage.enable` — one-line activation
  - `modelDir`, `dbPath`, `camera`, `similarityThreshold`, `logLevel`
  - `pam.enable` — configures PAM for sudo + login with face-before-password
  - Hardened systemd service (mirrors `visaged.service`)
  - D-Bus policy via `services.dbus.packages`
  - tmpfiles rules for `/var/lib/visage`
  - Suspend/resume restart service
- **`flake.nix`** (new, repo root) — exposes `packages.visage`, `devShells.default` (rust-analyzer, cargo-deb, cargo-watch), `nixosModules.default`

### Arch Linux (AUR)

- **`PKGBUILD`** — adds `check()` function (unit tests), `backup` array (`faces.db`), `provides`/`conflicts`, explicit `systemd` dep, `CARGO_TARGET_DIR` export
- **`visage.install`** — rewritten with:
  - Structured 4-step `post_install` with numbered setup guide and exact PAM line
  - `post_upgrade` with daemon restart and pre-0.3.0 re-enrollment guidance
  - `post_remove` with manual PAM cleanup reminder and data retention note

### Docs

- **README.md** — restructured Installation section: Ubuntu/Debian, NixOS (flake), Arch Linux (AUR)
- **operations-guide.md** — NixOS and Arch install paths with all PAM notes

## Testing

- `cargo test --workspace`: 59/59 pass
- `cargo clippy --workspace -- -D warnings`: clean
- NixOS and Arch packages cannot be tested on this Ubuntu system but are structurally complete

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] No new warnings introduced
- [x] I have read CONTRIBUTING.md