### PR TITLE
docs: fix outdated version references and add euclidean_distance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Bugs fixed during testing: [DeviceAllow glob](docs/STATUS.md#bugs-found-during-t
 - [Release Status & Known Limitations](docs/STATUS.md)
 - [Architecture](docs/architecture.md)
 - [Threat Model](docs/threat-model.md)
-- [Architecture Decisions](docs/decisions/) ← 10 ADRs covering implementation, security, and governance decisions
+- [Architecture Decisions](docs/decisions/) ← 11 ADRs covering implementation, security, governance, and liveness detection
 
 ## Security
 

--- a/crates/visage-core/src/types.rs
+++ b/crates/visage-core/src/types.rs
@@ -266,4 +266,56 @@ mod tests {
         assert!(!result.matched);
         assert_eq!(result.similarity, 0.0);
     }
+
+    #[test]
+    fn test_euclidean_distance_identical() {
+        let a = Embedding {
+            values: vec![1.0, 2.0, 3.0],
+            model_version: None,
+        };
+        let b = Embedding {
+            values: vec![1.0, 2.0, 3.0],
+            model_version: None,
+        };
+        assert!(a.euclidean_distance(&b).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_euclidean_distance_orthogonal() {
+        let a = Embedding {
+            values: vec![1.0, 0.0],
+            model_version: None,
+        };
+        let b = Embedding {
+            values: vec![0.0, 1.0],
+            model_version: None,
+        };
+        assert!((a.euclidean_distance(&b) - 2.0_f32.sqrt()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_euclidean_distance_opposite() {
+        let a = Embedding {
+            values: vec![1.0, 0.0],
+            model_version: None,
+        };
+        let b = Embedding {
+            values: vec![-1.0, 0.0],
+            model_version: None,
+        };
+        assert!((a.euclidean_distance(&b) - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_euclidean_distance_known() {
+        let a = Embedding {
+            values: vec![0.0, 0.0, 0.0],
+            model_version: None,
+        };
+        let b = Embedding {
+            values: vec![3.0, 4.0, 0.0],
+            model_version: None,
+        };
+        assert!((a.euclidean_distance(&b) - 5.0).abs() < 1e-6);
+    }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,18 +217,18 @@ Useful for hardware support debugging before filing a quirk contribution.
 /dev/video4  VID=0x0bda PID=0x5850  no quirk (VID=0x0bda PID=0x5850)
 ```
 
-### Known Limitations (Step 5)
+### Known Limitations (IR Emitter)
 
 1. **One compiled-in quirk.** Adding a new camera requires a new `contrib/hw/*.toml`
    file and a rebuild. A runtime override directory (`/usr/share/visage/quirks/`) is
-   deferred to Step 6.
+   planned for a future release.
 
 2. **No udev rule.** Read+write access to `/dev/videoN` requires root or the `video`
-   group. A udev rule granting `visaged` access is deferred to Step 6.
+   group. A udev rule granting `visaged` access is planned for a future release.
 
-3. **100ms AGC warm-up is hardcoded.** `VISAGE_EMITTER_WARM_UP_MS` is deferred to Step 6.
+3. **100ms AGC warm-up is hardcoded.** `VISAGE_EMITTER_WARM_UP_MS` is planned for a future release.
 
-4. **`visage discover --probe` (test activation pulse) deferred to Step 6.**
+4. **`visage discover --probe` (test activation pulse) planned for a future release.**
 
 See [ADR 006](decisions/006-ir-emitter-integration.md) for full decision log.
 
@@ -522,21 +522,18 @@ pkexec vim /etc/pam.d/sudo
 su -c "vim /etc/pam.d/sudo"
 ```
 
-### Known Limitations (Step 4)
+### Known Limitations (PAM Module)
 
 1. **D-Bus timeout: 10–25 s.** Under normal conditions the daemon's 10 s verify timeout
    fires first. If the daemon deadlocks, the D-Bus default (~25 s) applies. A 3 s
-   client-side timeout is deferred to Step 6.
+   client-side timeout is planned for a future release.
 
 2. **No caller authentication.** The `user` string passed to `Verify()` comes from
-   `pam_get_user` and is not validated against D-Bus peer credentials. Step 6 should
-   use `GetConnectionCredentials` to bind the call to the authenticated PAM user.
+   `pam_get_user` and is not validated against D-Bus peer credentials. Future releases
+   should use `GetConnectionCredentials` to bind the call to the authenticated PAM user.
 
-3. **Development-only PAM config.** Manual `/etc/pam.d/sudo` edit. `pam-auth-update`
-   integration is Step 6 (packaging).
-
-4. **`eprintln!` logging.** Messages appear in the `sudo` terminal. Production syslog
-   (`LOG_AUTHPRIV`) is deferred to Step 6.
+3. **`eprintln!` logging.** Messages appear in the `sudo` terminal. Production syslog
+   (`LOG_AUTHPRIV`) is planned for a future release.
 
 See [ADR 005](decisions/005-pam-system-bus-migration.md) for full decision log.
 

--- a/docs/hardware-compatibility.md
+++ b/docs/hardware-compatibility.md
@@ -13,8 +13,8 @@ Run `visage discover` to get the answer for your machine.
 | Camera stack | `visage discover` output | Visage support |
 |-------------|--------------------------|----------------|
 | USB UVC | `driver=uvcvideo` | ✅ Supported |
-| Intel IPU6 | `driver=intel_ipu6*` | ❌ Not supported (v0.1) |
-| MIPI / libcamera | varies | ❌ Not supported (v0.1) |
+| Intel IPU6 | `driver=intel_ipu6*` | ❌ Not supported yet (v0.4+) |
+| MIPI / libcamera | varies | ❌ Not supported yet (v0.4+) |
 
 ---
 
@@ -49,7 +49,7 @@ Run `visage discover` to get the answer for your machine.
 | Brand / Line | IR camera | Linux driver | Notes |
 |---|---|---|---|
 | **Dell XPS** 15/16 (2023+) | Yes | `intel_ipu6` | IPU6 camera stack. Even the RGB webcam may not work on Linux without distro-specific libcamera support. |
-| **Microsoft Surface** (all lines) | Yes | Custom HAL | Requires linux-surface kernel patches + libcamera. IR via PAM not practical in v0.1. |
+| **Microsoft Surface** (all lines) | Yes | Custom HAL | Requires linux-surface kernel patches + libcamera. IR via PAM not practical yet. |
 
 ---
 
@@ -103,7 +103,7 @@ VID:PID to the correct control bytes for each known device.
 
 ## IPU6 support timeline
 
-Intel IPU6 cameras are on the v0.3 roadmap. Supporting them requires libcamera
+IPU6 cameras are planned for future versions. Supporting them requires libcamera
 integration rather than direct V4L2 capture, which is a substantial architectural
 addition. The primary blockers are:
 


### PR DESCRIPTION
## Summary

- **Documentation fixes:** Updated outdated version references across README.md, architecture.md, and hardware-compatibility.md
  - Fixed ADR count (10 → 11) in README
  - Replaced obsolete "Step 4/5/6" references with component names (all implementation steps are complete)
  - Updated "v0.1" references to "v0.4+" for IPU6/MIPI camera support status
  
- **New tests:** Added 4 unit tests for `Embedding::euclidean_distance()` which had zero test coverage
  - `test_euclidean_distance_identical` — distance between identical vectors is 0
  - `test_euclidean_distance_orthogonal` — distance between [1,0] and [0,1] is √2
  - `test_euclidean_distance_opposite` — distance between [1,0] and [-1,0] is 2
  - `test_euclidean_distance_known` — 3-4-5 triangle verification

## Testing

- [x] `cargo test -p visage-core` — all 42 tests pass (38 existing + 4 new)
- [x] `cargo test -p visage-models` — all 4 tests pass
- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo clippy -p visage-core -- -D warnings` — no warnings

## Quality Gate

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (no new warnings)
- [x] `cargo test --workspace` passes (where buildable without system deps)
- [x] DCO sign-off included