### PR TITLE
packaging/aur: disable LTO and debug to fix Arch build

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -12,6 +12,8 @@ depends=('pam' 'dbus' 'systemd')
 makedepends=('rust' 'cargo' 'pkg-config')
 provides=('visage')
 conflicts=('visage')
+# LTO breaks ring's hand-written asm and rusqlite's bundled sqlite3 native objects
+options=(!lto !debug)
 install="$pkgname.install"
 # Preserve user data and face database across upgrades
 backup=('var/lib/visage/faces.db')


### PR DESCRIPTION
### Type

- [x] Distribution packaging

### Description

Building from `packaging/aur/PKGBUILD` on a stock Arch system fails at link time with two clusters of undefined-symbol errors:

```
ld.lld: error: undefined symbol: ring_core_0_17_14__LIMBS_window5_split_window
... (many more from ring)
ld.lld: error: undefined symbol: sqlite3_threadsafe
... (many more from libsqlite3-sys)
```

Arch's `/etc/makepkg.conf` enables `OPTIONS=(... lto ...)` by default. LTO operates on LLVM IR, but `ring` ships hand-written assembly via `cc`, and `libsqlite3-sys` (used through rusqlite's `bundled` feature) compiles `sqlite3.c` via `cc`. Those `.o` files have no LTO-compatible IR, so the final link drops or fails to resolve their symbols.

Disabling LTO at the package level fixes the build. `!debug` is included because the debug split adds nothing useful for a Rust package built this way.

### Testing

Built from a clean clone on Arch with `rust 1.95.0`, `cargo 1.95.0`, `gcc 16.1.1`, `sdbus-c++ 2.2.1`. Without the patch, `makepkg -si` fails as above. With the patch, it succeeds and installs `visage`, `visaged`, and `pam_visage.so`. Verified runtime: `visage discover`, `sudo visage setup`, `visage enroll`, and `visage verify` all work; `pam_visage.so` authenticates via `/etc/pam.d/sudo`.

### Checklist

- [x] No new warnings introduced

The `cargo fmt / clippy / test` items don't apply — this PR only touches `packaging/aur/PKGBUILD`, no Rust source changes.

### Breaking changes

None.
