### PR TITLE
Add camera quirk for Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS 174f:2454

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Confirmed quirk entries:
 | File | Device | Source |
 |------|--------|--------|
 | `04f2-b6d9.toml` | ASUS Zenbook 14 UM3406HA | Verified on hardware |
+| `174f-2454.toml` | Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS | Verified on hardware |
 
 To add support for your camera, see [contrib/hw/README.md](contrib/hw/README.md).
 

--- a/contrib/hw/174f-2454.toml
+++ b/contrib/hw/174f-2454.toml
@@ -1,0 +1,11 @@
+[device]
+vendor_id  = 0x174F
+product_id = 0x2454
+name       = "Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS"
+
+[emitter]
+# UVC extension unit control parameters (from reverse engineering)
+unit     = 4
+selector = 6
+# control_bytes: payload to activate; zeros of same length deactivate
+control_bytes = [1, 3, 2, 0, 0, 0, 0, 0, 0]

--- a/crates/visage-hw/src/quirks.rs
+++ b/crates/visage-hw/src/quirks.rs
@@ -9,6 +9,8 @@ use std::sync::OnceLock;
 
 /// Compile-time embedded quirk for the ASUS Zenbook 14 UM3406HA IR camera.
 const QUIRK_04F2_B6D9: &str = include_str!("../../../contrib/hw/04f2-b6d9.toml");
+/// Compile-time embedded quirk for the Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS IR camera.
+const QUIRK_174F_2454: &str = include_str!("../../../contrib/hw/174f-2454.toml");
 
 static QUIRK_DB: OnceLock<Vec<QuirkFile>> = OnceLock::new();
 
@@ -43,7 +45,7 @@ pub type CameraQuirk = QuirkFile;
 fn quirk_db() -> &'static Vec<QuirkFile> {
     QUIRK_DB.get_or_init(|| {
         let mut db = Vec::new();
-        for src in [QUIRK_04F2_B6D9] {
+        for src in [QUIRK_04F2_B6D9, QUIRK_174F_2454] {
             match toml::from_str::<QuirkFile>(src) {
                 Ok(q) => db.push(q),
                 Err(e) => eprintln!("visage-hw: bad quirk TOML: {e}"),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,6 +146,7 @@ a `OnceLock<Vec<QuirkFile>>` at first access.
 | File | Camera | VID | PID |
 |------|--------|-----|-----|
 | `04f2-b6d9.toml` | ASUS Zenbook 14 UM3406HA | `0x04F2` | `0xB6D9` |
+| `174f-2454.toml` | Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS | `0x174F` | `0x2454` |
 
 ### Device Discovery
 

--- a/docs/hardware-compatibility.md
+++ b/docs/hardware-compatibility.md
@@ -103,6 +103,7 @@ VID:PID to the correct control bytes for each known device.
 | Device | VID:PID | Status |
 |--------|---------|--------|
 | ASUS Zenbook 14 UM3406HA | `04f2:b6d9` | ✅ Verified on hardware |
+| Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS | `174f:2454` | ✅ Verified on hardware |
 
 **Contributing a quirk for your camera:**
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -276,6 +276,7 @@ The emitter quirks database lives in `contrib/hw/`. Currently supported:
 | Camera | VID | PID | File |
 |--------|-----|-----|------|
 | ASUS Zenbook 14 UM3406HA | `0x04F2` | `0xB6D9` | `04f2-b6d9.toml` |
+| Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS | `0x174F` | `0x2454` | `174f-2454.toml` |
 
 For unsupported cameras, run `visage discover` to get the VID:PID, then follow the
 contribution guide at [contrib/hw/README.md](../contrib/hw/README.md).


### PR DESCRIPTION
## Type

- [x] Hardware quirk (`contrib/hw/*.toml`)
- [ ] Bug fix
- [ ] Distribution packaging
- [x] Documentation
- [ ] Other: <!-- describe -->

## Description

Add camera quirk for Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS
USB VID:PID - 174f:2454

## Testing

/dev/video0  driver=uvcvideo  VID=0x174f PID=0x2454  quirk: Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS ✓
/dev/video1  driver=uvcvideo  VID=0x174f PID=0x2454  quirk: Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS ✓
/dev/video2  driver=uvcvideo  VID=0x174f PID=0x2454  quirk: Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS ✓
/dev/video3  driver=uvcvideo  VID=0x174f PID=0x2454  quirk: Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS ✓

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] No new warnings introduced
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Breaking changes

No