### PR TITLE
fix(visaged): handle SIGTERM (closes #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`visaged` now handles SIGTERM correctly.** The shutdown signal handler in
+  `crates/visaged/src/main.rs` previously relied on `tokio::signal::ctrl_c()`,
+  which is SIGINT-only on Unix. `systemctl stop` / `systemctl restart` (and
+  `visage-resume.service` after suspend/hibernate) send SIGTERM, which the daemon
+  ignored — systemd then waited the default `TimeoutStopSec=90s` before escalating
+  to SIGKILL, manifesting as a ~90s hang on `systemctl restart visaged.service`
+  after hibernate resume. Visaged now installs handlers for both SIGINT and SIGTERM
+  via `tokio::signal::unix::signal` and shuts down cleanly. Fixes #26.
+- **`visaged.service` adds `TimeoutStopSec=10s`** as defense in depth — covers the
+  edge case where a v4l2 capture is mid-flight and not promptly interruptible
+  (e.g. a stale camera fd after hibernate resume). Fixes #26.
+
 ### Documentation
 
 - Added ASUS ExpertBook B3302FEA/B5302FEA hardware validation showing the built-in

--- a/crates/visaged/src/main.rs
+++ b/crates/visaged/src/main.rs
@@ -93,10 +93,10 @@ async fn main() -> Result<()> {
     // 90s) elapses and systemd escalates to SIGKILL. See issue #26.
     {
         use tokio::signal::unix::{signal, SignalKind};
-        let mut sigterm = signal(SignalKind::terminate())
-            .context("failed to install SIGTERM handler")?;
-        let mut sigint = signal(SignalKind::interrupt())
-            .context("failed to install SIGINT handler")?;
+        let mut sigterm =
+            signal(SignalKind::terminate()).context("failed to install SIGTERM handler")?;
+        let mut sigint =
+            signal(SignalKind::interrupt()).context("failed to install SIGINT handler")?;
         tokio::select! {
             _ = sigterm.recv() => tracing::info!(signal = "SIGTERM", "received shutdown signal"),
             _ = sigint.recv()  => tracing::info!(signal = "SIGINT",  "received shutdown signal"),

--- a/crates/visaged/src/main.rs
+++ b/crates/visaged/src/main.rs
@@ -87,8 +87,21 @@ async fn main() -> Result<()> {
         "visaged ready — listening on org.freedesktop.Visage1"
     );
 
-    // 5. Wait for shutdown signal
-    tokio::signal::ctrl_c().await?;
+    // 5. Wait for shutdown signal (SIGINT or SIGTERM).
+    // systemd's `systemctl stop|restart` sends SIGTERM, which `tokio::signal::ctrl_c`
+    // does not catch — so a ctrl_c-only handler stalls until `TimeoutStopSec` (default
+    // 90s) elapses and systemd escalates to SIGKILL. See issue #26.
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm = signal(SignalKind::terminate())
+            .context("failed to install SIGTERM handler")?;
+        let mut sigint = signal(SignalKind::interrupt())
+            .context("failed to install SIGINT handler")?;
+        tokio::select! {
+            _ = sigterm.recv() => tracing::info!(signal = "SIGTERM", "received shutdown signal"),
+            _ = sigint.recv()  => tracing::info!(signal = "SIGINT",  "received shutdown signal"),
+        }
+    }
     tracing::info!("visaged shutting down");
 
     Ok(())

--- a/packaging/systemd/visaged.service
+++ b/packaging/systemd/visaged.service
@@ -8,6 +8,11 @@ Type=simple
 ExecStart=/usr/bin/visaged
 Restart=on-failure
 RestartSec=5
+# Defense in depth against a stuck capture loop on `systemctl stop|restart`.
+# Visaged handles SIGINT + SIGTERM at the runtime layer (see issue #26); this
+# bound covers the case where a v4l2 capture is mid-flight and not promptly
+# interruptible (e.g. after hibernate resume with a stale camera fd).
+TimeoutStopSec=10s
 Environment=VISAGE_MODEL_DIR=/var/lib/visage/models
 Environment=VISAGE_DB_PATH=/var/lib/visage/faces.db
 Environment=RUST_LOG=visaged=info


### PR DESCRIPTION
## Summary

Closes #26 — `systemctl restart visaged.service` hangs for ~90s after hibernate resume because `visaged` ignores SIGTERM.

## Root cause

`crates/visaged/src/main.rs:91` used `tokio::signal::ctrl_c().await?` for shutdown. On Unix, `tokio::signal::ctrl_c()` is **SIGINT-only**. systemd's `systemctl stop` / `systemctl restart` sends **SIGTERM**, which the daemon has no handler for — so systemd waits the default `TimeoutStopSec=90s` before escalating to SIGKILL. Reported as the ~90s window during which face auth doesn't work after `visage-resume.service` fires.

Note: this is independent of the stale-camera-fd concern in the original report. The fd may indeed go bad across hibernate, but the user-visible 90s hang is entirely on the signal-handling side — we never reach any shutdown / fd-teardown path.

## Fix

Two changes:

1. **`crates/visaged/src/main.rs`** — install handlers for both SIGINT and SIGTERM via `tokio::signal::unix::signal(SignalKind::terminate())` + `SignalKind::interrupt()`, awaited in a `tokio::select!`. Matches the pattern used in our other daemons (e.g. `esver-capture-cli`'s `wait_for_shutdown_signal`).
2. **`packaging/systemd/visaged.service`** — add `TimeoutStopSec=10s` as defense in depth, in case a v4l2 capture is mid-flight and not promptly interruptible (e.g. a stale camera fd on hibernate resume that the v4l ioctl can't immediately abort).

## Verification

- Mechanical correctness: the engine task is parked on `rx.blocking_recv()` (`crates/visaged/src/engine.rs:166`); when `main` returns and the tokio runtime drops, the channel sender drops, the engine thread exits cleanly. No new shutdown plumbing required.
- Worst-case `systemctl restart` goes from ~90s → ~10s for the rare case where the capture loop genuinely can't unwind in time.
- Local `cargo check` blocked on a devshell gap (missing `libclang` for `v4l2-sys` bindgen, missing `rustfmt`/`clippy`) — CI will run all gates. I'll file a separate PR to round out the devshell.

## Test plan

- [ ] CI: `cargo fmt --all -- --check` clean
- [ ] CI: `cargo clippy --workspace -- -D warnings` clean
- [ ] CI: `cargo test --workspace` green
- [ ] CI: `build-deb` produces a `.deb` cleanly
- [ ] Manual on a hibernate-capable system (Surface / ThinkPad pre-Gen11 / EliteBook / Zenbook 14):
  - `sudo systemctl restart visaged.service` returns in ~1s when idle (was ~1s before, should still be ~1s — sanity check)
  - `sudo systemctl restart visaged.service` returns in ≤10s after hibernate resume (previously ~90s)
  - Face auth resumes working without further intervention

## CHANGELOG

Entry added under `[Unreleased] > Fixed`. Will land in v0.3.2 per the release plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)