### PR TITLE
chore(devshell): add rustfmt + clippy + libclang for parity with CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,21 @@
         devShells.default = pkgs.mkShell {
           inputsFrom = [ visage ];
           packages = with pkgs; [
+            # Toolchain extras that match the CI gates
+            # (`cargo fmt --check`, `cargo clippy -- -D warnings`).
+            # `inputsFrom = [ visage ]` brings the compiler but not these.
+            rustfmt
+            clippy
+            # `bindgen` (transitively via `v4l2-sys-mit`) needs libclang.so
+            # at build time; without LIBCLANG_PATH set, `cargo build -p
+            # visaged` in the devshell fails with "Unable to find libclang".
+            llvmPackages.libclang
             rust-analyzer
             cargo-deb
             cargo-watch
           ];
+          # Tell bindgen where to find libclang at build time.
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
         };
       }
     ) // {


### PR DESCRIPTION
## Summary

The `nix develop` shell brings the build inputs of the `visage` package via `inputsFrom`, but not the cargo subcommands that CI gates on:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`

`dtolnay/rust-toolchain@stable` bundles both in the CI workflow (`.github/workflows/ci.yml`); our `devShells.default` doesn't. A contributor running `nix develop && cargo fmt` hits `error: no such command: \`fmt\`` — same for clippy.

Also exposes `llvmPackages.libclang` + `LIBCLANG_PATH`, since `v4l2-sys-mit` runs `bindgen` at build time and fails with "Unable to find libclang" otherwise. Caught when running `cargo check -p visaged` in the devshell.

## Diff

```nix
devShells.default = pkgs.mkShell {
  inputsFrom = [ visage ];
  packages = with pkgs; [
+    rustfmt
+    clippy
+    llvmPackages.libclang
     rust-analyzer
     cargo-deb
     cargo-watch
   ];
+  LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
};
```

## Scope

- No effect on CI (CI doesn't use the devshell).
- No effect on packaged outputs (only touches `devShells.default`).
- No version bump.

## Verification

In a freshly-entered `nix develop`:

```
$ which rustfmt cargo-clippy
/nix/store/...-rustfmt-1.95.0/bin/rustfmt
/nix/store/...-clippy-1.95.0/bin/cargo-clippy

$ echo $LIBCLANG_PATH
/nix/store/...-clang-21.1.8-lib/lib

$ cargo fmt --all -- --check    # clean on current main
$ cargo clippy --workspace -- -D warnings    # CI parity
```

Catches a real contributor friction point — surfaced by my own attempts to verify the SIGTERM fix (#30) and the PAM sweep (#31) before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)