### PR TITLE
release: v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.3.2 — 2026-05-28
+
 ### Fixed
 
 - **PAM control keyword corrected: `success=end` → `success=done` across all 9 sites.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "pam-visage"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "libc",
  "zbus",
@@ -2793,7 +2793,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visage-cli"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "visage-core"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "image",
  "ndarray",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "visage-hw"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "libc",
  "serde",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "visage-models"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "sha2",
  "thiserror",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "visaged"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sovren-software/visage"

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -2,7 +2,7 @@
 # https://github.com/sovren-software/visage
 
 pkgname=visage
-pkgver=0.3.0
+pkgver=0.3.2
 pkgrel=1
 pkgdesc="Linux face authentication via PAM — persistent daemon, IR camera support, ONNX inference"
 arch=('x86_64')
@@ -16,7 +16,7 @@ install="$pkgname.install"
 # Preserve user data and face database across upgrades
 backup=('var/lib/visage/faces.db')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/sovren-software/visage/archive/refs/tags/v$pkgver.tar.gz")
-# TODO: compute real sha256sum at release time: sha256sum visage-0.3.0.tar.gz
+# TODO: compute real sha256sum at release time: sha256sum visage-0.3.2.tar.gz
 sha256sums=('SKIP')
 
 build() {

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -19,7 +19,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "visage";
-  version = "0.3.0";
+  version = "0.3.2";
 
   src = lib.cleanSource ../..;
 


### PR DESCRIPTION
## Summary

Bug-fix release covering two **real shipping-user issues** in v0.3.0:

### Fixed

1. **PAM control keyword:** `success=end` → `success=done` across all 9 sites.
   - `pam.conf(5)` documents exactly `ignore | bad | die | ok | done | reset | N`. `end` is not in that list — libpam logged a warning and treated it as `ignore`, dropping `pam_visage.so`'s `PAM_SUCCESS` and falling through to the next rule.
   - In practice: **face auth has been working as if Visage weren't installed since v0.1.0** on the documented setup paths. Users got the password prompt every time, on top of the (silently-discarded) face match.
   - Landed via #31. Reported-by @SelfRef in #27.
   - **User upgrade impact:** Debian/Ubuntu users auto-recover on next `.deb` upgrade (postinst runs `pam-auth-update --package visage`). Arch and NixOS users get the fix from this install/rebuild.

2. **`visaged` SIGTERM handler** + `TimeoutStopSec=10s` on the unit.
   - `tokio::signal::ctrl_c()` is SIGINT-only; systemd's `systemctl stop|restart` sends SIGTERM, which the daemon ignored — systemd waited the default `TimeoutStopSec=90s` and finally SIGKILL'd.
   - Manifested as a ~90s hang on `systemctl restart visaged.service` after hibernate, when `visage-resume.service` fires automatically.
   - Landed via #30. Closes #26 (reported by @SomeCodecat).
   - **User upgrade impact:** worst-case `systemctl restart` bounded from ~90s → ~10s.

## Release artifacts

This PR is structured so the squash-commit subject is `release: v0.3.2`, which triggers `.github/workflows/ci.yml`'s `release` job on push to main. The workflow:

- Builds the workspace + the `.deb` via `cargo-deb`
- Reads the version from `Cargo.toml` (now `0.3.2`)
- Creates a GitHub Release tagged `v0.3.2` with the `.deb` attached, `body_path: CHANGELOG.md`, `prerelease: true`

## Version bump sweep

5 files touched:

| File | Bump |
|---|---|
| `Cargo.toml` (workspace.package.version) | `0.3.0` → `0.3.2` |
| `Cargo.lock` (6 workspace crate versions) | `0.3.0` → `0.3.2` |
| `packaging/aur/PKGBUILD` (`pkgver` + sha256sum TODO comment) | `0.3.0` → `0.3.2` |
| `packaging/nix/default.nix` (derivation version) | `0.3.0` → `0.3.2` |
| `CHANGELOG.md` | `## Unreleased` renamed to `## v0.3.2 — 2026-05-28`; new empty `## Unreleased` re-added at top |

Verified no other `0.3.0` references in workspace files (only legit historical CHANGELOG entry + unrelated transitive deps).

## Skipping v0.3.1

v0.3.1 was reserved for the **dependency-bump cohort** (tokio, image, uuid, nix, GitHub Actions) plus the **community fork PRs** (#25 Arch LTO fix, #29 X1 Carbon quirk). All five are still queued — the deps already merged to main but the two community PRs are blocked on maintainer workflow approval. Once they land, v0.3.3 picks up that cohort.

Cutting v0.3.2 first prioritizes the two real shipping-user bugs over the cosmetic bumps.

## Test plan

- [ ] CI: `test` job (fmt, clippy, build, test) green on the squash commit
- [ ] CI: `build-deb` produces `visage_0.3.2_amd64.deb`
- [ ] CI: `release` job (gated on `release:` prefix) fires and creates the GH release
- [ ] Post-release: `gh release view v0.3.2` shows the tagged release with `.deb` attached
- [ ] Manual (downstream): `visage-bin` AUR maintainer can pull the new `.deb` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)