### PR TITLE
fix(nix): add openssl to buildInputs for ort/openssl-sys (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Fixed
+
+- **NixOS / Nix flake build: add `openssl` to `buildInputs`** (issue #38). The
+  Nix derivation failed to build because `ort` (ONNX Runtime) pulls in `ureq` →
+  `native-tls` → `openssl-sys`, whose build script needs the system OpenSSL
+  library at link time. `nativeBuildInputs` already provided `pkg-config`, but
+  `buildInputs` was missing `openssl`, so `openssl-sys` could not locate it.
+  A follow-up can drop the C TLS dependency entirely by building `ort` with
+  `default-features = false, features = ["load-dynamic"]` against
+  `pkgs.onnxruntime`.
+
 ## v0.3.3 — 2026-05-28
 
 ### Added

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -14,6 +14,7 @@
 , pkg-config
 , pam
 , dbus
+, openssl
 , substituteAll ? null
 }:
 
@@ -26,7 +27,9 @@ rustPlatform.buildRustPackage {
   cargoLock.lockFile = ../../Cargo.lock;
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ pam dbus ];
+  # openssl: `ort` (ONNX Runtime) pulls `ureq` → `native-tls` → `openssl-sys`,
+  # whose build script needs the system OpenSSL at link time (issue #38).
+  buildInputs = [ pam dbus openssl ];
 
   # cargo test runs unit tests; integration tests require a camera + daemon
   doCheck = true;


### PR DESCRIPTION
## What

Adds `openssl` to the Nix derivation's `buildInputs` (and the corresponding function argument) so `nix build .#visage` / the flake build succeeds.

## Why

`ort` (ONNX Runtime, used by `visage-core`) runs with default features, enabling `download-binaries` → `ureq` → `native-tls` → `openssl-sys`. `openssl-sys`'s build script needs the system OpenSSL library at link time. The derivation already had `pkg-config` in `nativeBuildInputs`, but `buildInputs` was missing `openssl`, so the build failed (issue #38).

`flake.nix` uses `callPackage`, so the new `openssl` argument auto-fills from nixpkgs — no other wiring needed.

## Follow-up (intentionally not in this PR)

The C TLS dependency can be dropped entirely by building `ort` with `default-features = false, features = ["load-dynamic"]` against `pkgs.onnxruntime`, removing the `ureq → native-tls → openssl` chain — worth doing for a security-critical PAM project. Left separate since it touches `Cargo.toml`/`Cargo.lock` and the module's runtime `.so` path.

## Verification

Authored on a host without `cargo`/`nix`, so **not built locally** — relying on CI. The change is a one-line `buildInputs` addition plus the matching function argument and a CHANGELOG entry.

Closes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wU47GVzskAummZqgH6FgF
