### PR TITLE
chore(release): 0.3.4

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,26 @@
+name: Security Audit
+
+on:
+  schedule:
+    # Weekly (Mondays 06:00 UTC). Advisories appear independently of code changes,
+    # so this runs on a schedule rather than gating every pull request.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.3.4 — 2026-07-07
+
 ### Fixed
 
 - **NixOS / Nix flake build: add `openssl` to `buildInputs`** (issue #38). The
@@ -24,6 +26,19 @@
   camera in-process after repeated capture failures instead of requiring a
   restart. The per-capture stream is retained, so the camera is still released
   between verifies and remains usable by other applications.
+- **AUR install hook: corrected PAM keyword `success=end` → `success=done`.**
+  `packaging/aur/visage.install` still printed the setup guidance with the
+  invalid `[success=end …]` action — the same bug fixed everywhere else in
+  v0.3.2. libpam treats the unknown `end` as `ignore`, so a user following the
+  printed line verbatim would get a silent face-auth no-op. Now prints
+  `[success=done default=ignore]`.
+
+### Security
+
+- **CI: added a scheduled `cargo audit` workflow** (`.github/workflows/audit.yml`).
+  It scans `Cargo.lock` against the RustSec advisory database weekly and on
+  demand, surfacing dependency advisories without waiting for a manual check.
+
 ## v0.3.3 — 2026-05-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "pam-visage"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "libc",
  "zbus",
@@ -2793,7 +2793,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visage-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "visage-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "image",
  "ndarray",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "visage-hw"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "libc",
  "serde",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "visage-models"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "sha2",
  "thiserror",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "visaged"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sovren-software/visage"

--- a/packaging/aur/visage.install
+++ b/packaging/aur/visage.install
@@ -16,7 +16,7 @@ post_install() {
     echo "     Add this line BEFORE 'auth required pam_unix.so' in"
     echo "     /etc/pam.d/system-auth:"
     echo ""
-    echo "       auth  [success=end default=ignore]  pam_visage.so"
+    echo "       auth  [success=done default=ignore]  pam_visage.so"
     echo ""
     echo "     Or for sudo only, add the same line to /etc/pam.d/sudo."
     echo "     On failure or daemon unavailability, password is used as fallback."


### PR DESCRIPTION
## v0.3.4 — patch release

Bundles the two already-merged fixes into a tagged release, plus two small release-hygiene items.

### Fixed
- **NixOS / Nix flake build** — `openssl` added to `buildInputs` (#38, merged in #56).
- **Camera capture degradation on shared webcams** — per-capture format re-assert + in-process self-heal (#48, merged in #57).
- **AUR install hook** — corrected the `success=end` → `success=done` PAM keyword in `packaging/aur/visage.install` (the same bug fixed everywhere else in v0.3.2 was still printed by the install hook).

### Security
- **CI** — added a scheduled `cargo audit` workflow (`.github/workflows/audit.yml`) that scans `Cargo.lock` against the RustSec advisory DB weekly + on demand.

### Deferred
- **aes-gcm 0.11 (#53)** — closed/deferred: it forces edition-2024 / MSRV 1.85 (a breaking bump for AUR/Debian packagers) with no CVE on 0.10.3. Revisit as part of a future 0.4.0.

### Not in this release
- **OmniBook X Flip (#47)** — a good external contribution, but its fork CI needs a maintainer "approve and run workflows" click before it can be validated + merged; it will land in the next release.

**Files:** `CHANGELOG.md` (Unreleased → v0.3.4), `Cargo.toml` + `Cargo.lock` (0.3.3 → 0.3.4), `packaging/aur/visage.install`, `.github/workflows/audit.yml`.

Authored on a host without `cargo`; the version bump + these files touch no Rust source, so the `test` gate runs the same tree already green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wU47GVzskAummZqgH6FgF
