### PR TITLE
chore(release): 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## v0.3.5 — 2026-07-07
+
+### Added
+
+- **Hardware support: HP OmniBook X Flip IR camera** (`30c9:0120`, Luxvisions).
+  Contributed by @mocha in #47. Adds an IR-emitter quirk-schema extension
+  (`off_bytes`, `reset_on_close`) for devices whose emitter rejects an all-zero
+  "off" write (`ERANGE`); existing quirk files are unaffected (both fields
+  default). Quirk file: `contrib/hw/30c9-0120.toml`.
+- **Hardware support: Lenovo ThinkBook 14 MP2PQAZG IR camera** (`30c9:00c2`).
+  Contributed in #45 (previously not captured in the changelog). Quirk file:
+  `contrib/hw/30c9-00c2.toml`.
+
+### Security
+
+- **`openssl` 0.10.75 → 0.10.81** and **`rustls-webpki` 0.103.9 → 0.103.13**
+  (Dependabot security updates, #60 / #59) — pull RustSec-advisory fixes into
+  the TLS dependency chain (`ort` → `ureq`).
+
 ## v0.3.4 — 2026-07-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "pam-visage"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "libc",
  "zbus",
@@ -2792,7 +2792,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visage-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "visage-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "image",
  "ndarray",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "visage-hw"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "libc",
  "serde",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "visage-models"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "sha2",
  "thiserror",
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "visaged"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sovren-software/visage"

--- a/docs/hardware-compatibility.md
+++ b/docs/hardware-compatibility.md
@@ -104,6 +104,8 @@ VID:PID to the correct control bytes for each known device.
 |--------|---------|--------|
 | ASUS Zenbook 14 UM3406HA | `04f2:b6d9` | ✅ Verified on hardware |
 | Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS | `174f:2454` | ✅ Verified on hardware |
+| Lenovo ThinkBook 14 MP2PQAZG | `30c9:00c2` | ✅ Verified on hardware |
+| HP OmniBook X Flip | `30c9:0120` | ✅ Verified on hardware |
 
 **Contributing a quirk for your camera:**
 


### PR DESCRIPTION
## v0.3.5 — hardware support + security

### Added
- **HP OmniBook X Flip IR camera** (`30c9:0120`) — @mocha, #47. Includes an IR-emitter quirk-schema extension (`off_bytes`, `reset_on_close`) for emitters that reject an all-zero "off" write (`ERANGE`); existing quirk files default cleanly.
- **Lenovo ThinkBook 14 MP2PQAZG IR camera** (`30c9:00c2`) — #45, now documented.

Both added to the verified-hardware table in `docs/hardware-compatibility.md`.

### Security
- **openssl** 0.10.75 → 0.10.81 and **rustls-webpki** 0.103.9 → 0.103.13 (Dependabot security updates #60 / #59) — pull RustSec-advisory fixes into the `ort → ureq` TLS chain.

**Files:** `CHANGELOG.md` (Unreleased → v0.3.5), `Cargo.toml` + `Cargo.lock` (0.3.4 → 0.3.5), `docs/hardware-compatibility.md`. No Rust source changes (the OmniBook code merged in #47), so the `test` gate runs the same tree already green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wU47GVzskAummZqgH6FgF
