### PR TITLE
docs: reflect v0.3.4 / v0.3.5 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ Linux-PAM — no kernel patches, no modified sudo.
 
 ## Status
 
-**v0.3.3 — feature-complete, end-to-end tested on Ubuntu 24.04.4 LTS.**
+**v0.3.5 — feature-complete, end-to-end tested on Ubuntu 24.04.4 LTS.**
 
 All 6 implementation steps complete. Verified: enroll, verify, PAM/sudo integration,
 systemd hardening, D-Bus access control, install/remove/purge lifecycle, suspend/resume.
-v0.3.3 expands IR emitter coverage to Lenovo ThinkPad X1 Carbon Gen 9 and ships bug
-fixes for the post-hibernate `systemctl restart` path and the PAM `success=` control
-keyword. See [CHANGELOG](CHANGELOG.md) for the full v0.3.1–v0.3.3 history.
+Since v0.3.3: fixed capture degradation on shared webcams (per-capture format re-assert +
+in-process camera self-heal), added IR-emitter coverage for the HP OmniBook X Flip and
+Lenovo ThinkBook 14, enabled Dependabot security updates + a scheduled `cargo audit`, and
+reframed contribution review around the problem a PR solves (see [CONTRIBUTING](CONTRIBUTING.md)).
+See [CHANGELOG](CHANGELOG.md) for the full history.
 
 | Step | Component | Status |
 |------|-----------|--------|
@@ -88,7 +90,7 @@ the [Operations Guide](docs/operations-guide.md).
 ### Ubuntu / Debian (.deb)
 
 ```bash
-sudo apt install ./visage_0.3.0_amd64.deb
+sudo apt install ./visage_0.3.5_amd64.deb
 sudo visage setup                          # download ONNX models (~182 MB)
 sudo visage enroll --label default         # enroll your face
 sudo echo "face auth works"                # test — face first, password fallback

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Visage v0.3 Release Status
 
-**Last updated:** 2026-05-28
-**Build state:** v0.3.3 shipped. All 6 implementation steps complete + model integrity enforcement + OSS governance + passive liveness detection + post-v0.3.0 bug fix wave (PAM `success=` keyword corrected, `visaged` SIGTERM handler, `visaged.service` `TimeoutStopSec=10s`). End-to-end tested on Ubuntu 24.04.4 LTS. IR emitter quirks DB now covers ASUS Zenbook 14 UM3406HA and Lenovo ThinkPad X1 Carbon Gen 9 20XW00FPUS. Passive liveness still awaits manual spoof testing on hardware.
+**Last updated:** 2026-07-07
+**Build state:** v0.3.5 shipped. All 6 implementation steps complete + model integrity enforcement + OSS governance + passive liveness detection. Since v0.3.3: fixed capture degradation on shared webcams (per-capture V4L2 format re-assert + in-process camera self-heal, #48); the IR emitter quirks DB now covers ASUS Zenbook 14 UM3406HA, Lenovo ThinkPad X1 Carbon Gen 9, Lenovo ThinkBook 14 MP2PQAZG, and HP OmniBook X Flip; NixOS flake build fixed; Dependabot security updates + a scheduled `cargo audit` enabled; contribution review reframed problem-first (ADR 010 §9). End-to-end tested on Ubuntu 24.04.4 LTS. Passive liveness still awaits manual spoof testing on hardware.
 
 ---
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -32,9 +32,9 @@ Linux deserves a biometric authentication layer that is **reliable, secure, and 
 
 ---
 
-## Where We Are: v0.3.3
+## Where We Are: v0.3.5
 
-**Shipped 2026-05-28. Bug-fix release wave (v0.3.2 → v0.3.3) on top of the v0.3.0 foundation.**
+**Shipped 2026-05-28 (v0.3.3) and 2026-07-07 (v0.3.4, v0.3.5), on top of the v0.3.0 foundation.**
 
 v0.3.0 (2026-02-23) shipped all 6 implementation steps end-to-end on Ubuntu 24.04.4 LTS.
 The v0.3.x point releases since then addressed two silent ship-time bugs and added
@@ -48,10 +48,22 @@ broader hardware + packaging coverage:
   Tier-1-verified hardware target after ASUS Zenbook 14 UM3406HA); AUR `!lto !debug`
   fix so `makepkg -si` succeeds on stock Arch; devshell parity with CI;
   7 dependency bumps.
+- **v0.3.4 (2026-07-07)** — fixed capture degradation on shared webcams. `visaged`
+  cached its V4L2 format once at open and never re-asserted it; a co-resident app (e.g. a
+  video call) could leave the device in another format, so `visaged` decoded garbage →
+  "no face detected" until a manual restart. Fix: per-capture format re-assert +
+  in-process camera self-heal (#48). Also: NixOS flake build fix (`openssl` in
+  `buildInputs`), corrected the AUR install hook's invalid `success=end` keyword, and a
+  scheduled `cargo audit` workflow.
+- **v0.3.5 (2026-07-07)** — IR-emitter hardware support for the HP OmniBook X Flip
+  (`30c9:0120`, with a quirk-schema extension for emitters that reject an all-zero "off"
+  write) and the Lenovo ThinkBook 14 MP2PQAZG (`30c9:00c2`); `openssl` + `rustls-webpki`
+  security bumps (Dependabot security updates now enabled). Contribution review reframed
+  problem-first (a PR is a "push request" — ADR 010 §9).
 
 | Component | What it delivers |
 |-----------|-----------------|
-| `visage-hw` | V4L2 capture, GREY/YUYV/Y16 format detection, CLAHE preprocessing, dark frame rejection. Quirks DB covers ASUS Zenbook 14 + Lenovo X1 Carbon Gen 9 |
+| `visage-hw` | V4L2 capture, GREY/YUYV/Y16 format detection, CLAHE preprocessing, dark frame rejection, per-capture format re-assert + camera self-heal. Quirks DB covers ASUS Zenbook 14, Lenovo X1 Carbon Gen 9, Lenovo ThinkBook 14, HP OmniBook X Flip |
 | `visage-core` | SCRFD face detection + ArcFace recognition via ONNX Runtime — CPU-capable, no CUDA required |
 | `visaged` | Persistent daemon — holds camera and model weights across auth requests, D-Bus IPC, SQLite WAL. SIGINT + SIGTERM shutdown handlers; `TimeoutStopSec=10s` defense in depth |
 | `pam-visage` | Thin PAM module — `PAM_IGNORE` fallback, never blocks, system bus. `[success=done default=ignore]` control flow (corrected v0.3.2) |


### PR DESCRIPTION
## What problem does this solve?

The docs still described the project as **v0.3.3** — README Status, `docs/STATUS.md`, and `docs/STRATEGY.md` all predated the v0.3.4 + v0.3.5 releases, so a reader saw a stale picture: no shared-webcam capture fix, no OmniBook/ThinkBook hardware, no dependency-security automation, no problem-first review.

## What this changes

Refreshes the three "where we are" surfaces to v0.3.5:

- **README Status** — v0.3.5 + a one-paragraph summary of what changed since v0.3.3.
- **docs/STATUS.md** — build state → v0.3.5; the quirks DB now lists all four verified devices.
- **docs/STRATEGY.md** — adds the v0.3.4 (shared-webcam capture fix #48, NixOS build, install-hook keyword fix, `cargo audit`) and v0.3.5 (OmniBook + ThinkBook hardware, security bumps, problem-first review) release entries + the quirks-DB row.

Docs-only — no code or product change, so no version bump or changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wU47GVzskAummZqgH6FgF
