### PR TITLE
harden: session-bus + liveness fail-closed, zbus tokio pin, root-only D-Bus checks (v0.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ## Unreleased
 
+## v0.3.6 — 2026-07-07
+
+Security hardening batch — defense-in-depth on the D-Bus authorization surface,
+a fail-open → fail-closed correction in passive liveness, and a runtime-safety
+pin on the async executor. No public API or wire-format changes.
+
+### Security
+
+- **In-process root check on the privileged D-Bus methods** (`Enroll`,
+  `RemoveModel`, `ListModels`). These were root-only by the system-bus policy
+  file (`org.freedesktop.Visage1.conf`) alone; a missing, mis-scoped, or
+  overly-permissive policy — or running on the session bus — could let a
+  non-root caller invoke enrollment mutation or the enrollment listing. The
+  daemon now re-verifies the caller is root (UID 0) inside each handler (skipped
+  on the session bus, development mode), mirroring the defense-in-depth `Verify`
+  already applied.
+- **`VISAGE_SESSION_BUS=0` no longer enables session-bus mode.** Session-bus
+  mode *skips* D-Bus caller-UID validation (development only). The flag was read
+  with `env::var(..).is_ok()`, so *any* value — including `VISAGE_SESSION_BUS=0`,
+  the natural way to turn it off — enabled it and silently disabled UID
+  validation (fail-open). It now enables only on a non-empty, non-`"0"` value;
+  unset, empty, and `"0"` all keep the secure system-bus default.
+- **Passive liveness now fails closed on insufficient landmark data.**
+  `check_landmark_stability` reported "live" when fewer than two landmark frames
+  were available (fail-open), so a match backed by only a single detectable
+  landmark frame bypassed the liveness gate entirely. It now returns not-live in
+  that case; the daemon surfaces it as a (rate-limited) non-match and the user
+  retries. `frames_per_verify` defaults to 3, so a live subject in normal
+  lighting is unaffected.
+
+### Changed
+
+- **Pinned `zbus` to the `tokio` executor** (`default-features = false,
+  features = ["tokio"]`; `pam-visage` re-adds `blocking-api`), following zbus's
+  own recommendation for tokio integration. `visaged` awaits tokio primitives
+  inside `#[zbus::interface]` handlers; on zbus's default `async-io` executor any
+  reactor-bound tokio call added later would panic with "no reactor running", and
+  a single transitive dependency could silently revert the whole process to
+  `async-io` via Cargo feature unification. This also removes the `async-io` /
+  `smol` executor stack from the dependency tree.
+
+### Added
+
+- **AES-256-GCM known-answer test + on-disk blob-format guard** (`visaged`).
+  Locks the embedding-encryption primitive against the NIST GCM test vector and
+  the stored blob layout (12-byte nonce ‖ ciphertext ‖ 16-byte GCM tag, with
+  AEAD tamper rejection), so a future `aes-gcm` upgrade cannot silently change
+  the on-disk format and orphan existing enrollments.
+
 ## v0.3.5 — 2026-07-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,79 +192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.3",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 1.1.3",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,30 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.3",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,12 +212,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -434,19 +331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -1074,12 +958,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "pam-visage"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "libc",
  "zbus",
@@ -1758,17 +1636,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,20 +1652,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.3",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2362,12 +2215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +2340,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -2792,7 +2640,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visage-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2810,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "visage-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "image",
  "ndarray",
@@ -2823,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "visage-hw"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "libc",
  "serde",
@@ -2836,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "visage-models"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "sha2",
  "thiserror",
@@ -2844,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "visaged"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3284,14 +3132,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
 dependencies = [
  "async-broadcast",
- "async-executor",
- "async-io",
- "async-lock",
- "async-process",
  "async-recursion",
- "async-task",
  "async-trait",
- "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",
@@ -3302,6 +3144,7 @@ dependencies = [
  "rustix 1.1.3",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sovren-software/visage"
@@ -20,8 +20,16 @@ rust-version = "1.75"
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 
-# D-Bus IPC
-zbus = "5"
+# D-Bus IPC.
+# Pin to the tokio executor and disable the default `async-io` feature (zbus's
+# own recommendation for tokio integration). `visaged` awaits tokio primitives
+# (mpsc/oneshot/Mutex) from inside `#[zbus::interface]` handlers; leaving zbus on
+# its default async-io executor makes any reactor-bound tokio call (e.g. a future
+# `tokio::time`) panic with "no reactor running". Keeping this on tokio also
+# prevents a transitive dep from silently reverting the whole process to async-io
+# via Cargo feature unification. `pam-visage` re-adds `blocking-api` for its
+# synchronous proxy (it drives zbus's internal tokio runtime via `block_on`).
+zbus = { version = "5", default-features = false, features = ["tokio"] }
 
 # Logging / tracing
 tracing = "0.1"

--- a/crates/pam-visage/Cargo.toml
+++ b/crates/pam-visage/Cargo.toml
@@ -10,5 +10,9 @@ name = "pam_visage"
 crate-type = ["cdylib"]
 
 [dependencies]
-zbus = { workspace = true }
+# `blocking-api` re-enables the synchronous proxy wrappers (`VisageProxyBlocking`,
+# `zbus::blocking::*`) that the workspace-level `default-features = false` drops.
+# The blocking calls run on zbus's lazily-initialised internal tokio runtime, so
+# the PAM module needs no ambient async runtime of its own.
+zbus = { workspace = true, features = ["blocking-api"] }
 libc = { workspace = true }

--- a/crates/visage-core/src/liveness.rs
+++ b/crates/visage-core/src/liveness.rs
@@ -47,18 +47,25 @@ const DEFAULT_MIN_EYE_DISPLACEMENT: f32 = 0.8;
 /// # Returns
 ///
 /// A [`LivenessResult`] indicating whether the landmark sequence passes the
-/// liveness check. Returns `is_live = true` (pass) if fewer than 2 frames
-/// are provided, since the check requires at least one frame pair.
+/// liveness check. **Fails closed:** if fewer than 2 landmark frames are
+/// provided there is no frame pair to compare, so the check cannot gather any
+/// eye-movement evidence and returns `is_live = false`. A liveness gate must
+/// never vouch for a subject it could not actually assess — reporting "live" on
+/// missing evidence would let a spoof that yields only a single detectable
+/// landmark frame bypass the check entirely. The engine invokes this only when
+/// liveness is enabled *and* a match otherwise succeeded, where a fail-closed
+/// result is surfaced as a (rate-limited) non-match and the user simply retries.
 pub fn check_landmark_stability(
     landmark_sequence: &[[(f32, f32); 5]],
     min_displacement: Option<f32>,
 ) -> LivenessResult {
     let threshold = min_displacement.unwrap_or(DEFAULT_MIN_EYE_DISPLACEMENT);
 
-    // Need at least 2 frames to compare
+    // Fewer than 2 frames → no frame pair → no eye-movement evidence.
+    // Fail closed: a liveness check that cannot gather evidence must NOT report live.
     if landmark_sequence.len() < 2 {
         return LivenessResult {
-            is_live: true, // cannot determine — pass through
+            is_live: false,
             mean_eye_displacement: 0.0,
             frame_pairs_analysed: 0,
         };
@@ -115,18 +122,20 @@ mod tests {
     }
 
     #[test]
-    fn test_single_frame_passes() {
-        // Cannot determine liveness with 1 frame — should pass through
+    fn test_single_frame_fails_closed() {
+        // Cannot determine liveness with 1 frame (no pair to compare) — must
+        // fail closed (reject) rather than vouch for an unassessed subject.
         let seq = vec![landmarks_with_eyes((100.0, 50.0), (140.0, 50.0))];
         let result = check_landmark_stability(&seq, None);
-        assert!(result.is_live);
+        assert!(!result.is_live);
         assert_eq!(result.frame_pairs_analysed, 0);
     }
 
     #[test]
-    fn test_empty_sequence_passes() {
+    fn test_empty_sequence_fails_closed() {
+        // No landmark data at all — must fail closed.
         let result = check_landmark_stability(&[], None);
-        assert!(result.is_live);
+        assert!(!result.is_live);
         assert_eq!(result.frame_pairs_analysed, 0);
     }
 

--- a/crates/visaged/src/config.rs
+++ b/crates/visaged/src/config.rs
@@ -67,7 +67,7 @@ impl Config {
                 .map(|v| v != "0")
                 .unwrap_or(true),
             liveness_min_displacement: env_f32("VISAGE_LIVENESS_MIN_DISPLACEMENT", 0.8),
-            session_bus: std::env::var("VISAGE_SESSION_BUS").is_ok(),
+            session_bus: parse_session_bus(std::env::var("VISAGE_SESSION_BUS").ok().as_deref()),
         }
     }
 
@@ -107,4 +107,51 @@ fn env_usize(key: &str, default: usize) -> usize {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(default)
+}
+
+/// Parse the `VISAGE_SESSION_BUS` value into the session-bus flag.
+///
+/// Security-sensitive: session-bus mode *skips* D-Bus caller-UID validation
+/// (see `dbus_interface::verify` and `require_root_caller`), so it must default
+/// to `false` (system bus, validation ON) and enable only on an explicit opt-in.
+/// An unset value, an empty value, and the literal `"0"` all keep it OFF — only a
+/// non-empty, non-`"0"` value (e.g. `"1"`) turns it on.
+///
+/// Previously this used `env::var(..).is_ok()`, so *any* presence of the
+/// variable — including `VISAGE_SESSION_BUS=0`, the natural way to try to turn it
+/// off — enabled session-bus mode and silently disabled UID validation: a
+/// fail-open trap. This helper closes it.
+fn parse_session_bus(value: Option<&str>) -> bool {
+    matches!(value, Some(v) if !v.is_empty() && v != "0")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_session_bus;
+
+    #[test]
+    fn session_bus_defaults_off_and_respects_zero() {
+        // Secure default: absent, empty, or "0" → system bus (UID validation ON).
+        assert!(
+            !parse_session_bus(None),
+            "unset must not enable session bus"
+        );
+        assert!(
+            !parse_session_bus(Some("")),
+            "empty must not enable session bus"
+        );
+        assert!(
+            !parse_session_bus(Some("0")),
+            "VISAGE_SESSION_BUS=0 must NOT enable session bus (was a fail-open trap)"
+        );
+        // Explicit opt-in: any non-empty, non-"0" value enables dev mode.
+        assert!(
+            parse_session_bus(Some("1")),
+            "\"1\" must enable session bus"
+        );
+        assert!(
+            parse_session_bus(Some("true")),
+            "any other non-empty value enables session bus"
+        );
+    }
 }

--- a/crates/visaged/src/dbus_interface.rs
+++ b/crates/visaged/src/dbus_interface.rs
@@ -46,19 +46,68 @@ fn uid_for_name(name: &str) -> Option<u32> {
     }
 }
 
+/// Defense-in-depth: require the D-Bus caller to be root (UID 0) for a
+/// privileged method (`Enroll`, `RemoveModel`, `ListModels`).
+///
+/// The system-bus policy (`org.freedesktop.Visage1.conf`) already restricts
+/// these methods to root by omission from the `default` context. This re-checks
+/// the caller's UID in-process so a missing, mis-scoped, or overly-permissive
+/// policy file cannot silently widen access to enrollment mutation or the
+/// enrollment listing. On the session bus (development mode) the check is
+/// skipped — mirroring `verify`'s UID validation, since all session-bus callers
+/// share one user and no system policy applies.
+async fn require_root_caller(
+    method: &str,
+    session_bus: bool,
+    header: &zbus::message::Header<'_>,
+    conn: &zbus::Connection,
+) -> zbus::fdo::Result<()> {
+    if session_bus {
+        return Ok(());
+    }
+    let sender = header
+        .sender()
+        .ok_or_else(|| zbus::fdo::Error::Failed("no sender in message".to_string()))?;
+    let caller_uid = get_caller_uid(sender.as_str(), conn).await?;
+    if caller_uid != 0 {
+        tracing::warn!(
+            method,
+            caller_uid,
+            "privileged method denied: caller is not root"
+        );
+        return Err(zbus::fdo::Error::AccessDenied(format!(
+            "method '{method}' requires root"
+        )));
+    }
+    Ok(())
+}
+
 #[interface(name = "org.freedesktop.Visage1")]
 impl VisageService {
     /// Enroll a new face model for the given user.
     ///
     /// Returns the UUID of the newly created model.
-    async fn enroll(&self, user: &str, label: &str) -> zbus::fdo::Result<String> {
+    async fn enroll(
+        &self,
+        user: &str,
+        label: &str,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+        #[zbus(connection)] conn: &zbus::Connection,
+    ) -> zbus::fdo::Result<String> {
         tracing::info!(user, label, "enroll requested");
 
         // Copy values while holding lock, then release
-        let (engine, frames_count) = {
+        let (engine, frames_count, session_bus) = {
             let state = self.state.lock().await;
-            (state.engine.clone(), state.config.frames_per_enroll)
+            (
+                state.engine.clone(),
+                state.config.frames_per_enroll,
+                state.config.session_bus,
+            )
         };
+
+        // Defense-in-depth (enrollment is a privileged mutation).
+        require_root_caller("Enroll", session_bus, &header, conn).await?;
 
         // Run engine (no lock held)
         let result = engine.enroll(frames_count).await.map_err(|e| {
@@ -262,8 +311,16 @@ impl VisageService {
     }
 
     /// List enrolled face models for the given user as JSON.
-    async fn list_models(&self, user: &str) -> zbus::fdo::Result<String> {
+    async fn list_models(
+        &self,
+        user: &str,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+        #[zbus(connection)] conn: &zbus::Connection,
+    ) -> zbus::fdo::Result<String> {
         tracing::info!(user, "list_models requested");
+        // Defense-in-depth: enrollment listing is a root-only operation.
+        let session_bus = self.state.lock().await.config.session_bus;
+        require_root_caller("ListModels", session_bus, &header, conn).await?;
         let state = self.state.lock().await;
         let models = state
             .store
@@ -274,8 +331,17 @@ impl VisageService {
     }
 
     /// Remove an enrolled face model by ID (scoped to user).
-    async fn remove_model(&self, user: &str, model_id: &str) -> zbus::fdo::Result<bool> {
+    async fn remove_model(
+        &self,
+        user: &str,
+        model_id: &str,
+        #[zbus(header)] header: zbus::message::Header<'_>,
+        #[zbus(connection)] conn: &zbus::Connection,
+    ) -> zbus::fdo::Result<bool> {
         tracing::info!(user, model_id, "remove_model requested");
+        // Defense-in-depth (removal is a privileged mutation).
+        let session_bus = self.state.lock().await.config.session_bus;
+        require_root_caller("RemoveModel", session_bus, &header, conn).await?;
         let state = self.state.lock().await;
         let removed = state
             .store

--- a/crates/visaged/src/engine.rs
+++ b/crates/visaged/src/engine.rs
@@ -472,7 +472,10 @@ fn run_verify(
 
     // --- Passive liveness check ---
     // Run after detection loop so we always have full landmark data.
-    // Only gates the result when a match would otherwise succeed.
+    // Only gates the result when a match would otherwise succeed. The check
+    // fails closed: fewer than 2 landmark frames yields `is_live = false`
+    // (rejected), so a spoof that produces only a single detectable landmark
+    // frame cannot slip past liveness by starving it of evidence.
     if liveness_enabled && result.matched {
         let liveness =
             check_landmark_stability(&landmark_sequence, Some(liveness_min_displacement));

--- a/crates/visaged/src/store.rs
+++ b/crates/visaged/src/store.rs
@@ -527,6 +527,76 @@ mod tests {
         assert!(store2.decrypt_embedding(&blob).is_err());
     }
 
+    /// Known-answer test locking the AES-256-GCM primitive against NIST GCM
+    /// test case 14 (256-bit all-zero key, 96-bit all-zero IV, 16-byte all-zero
+    /// plaintext). `aes-gcm`'s `encrypt` returns the ciphertext concatenated with
+    /// the 16-byte GCM tag.
+    ///
+    /// This is the golden guard for a future `aes-gcm` version bump (e.g. the
+    /// deferred 0.10 → 0.11 migration): any change that altered the primitive's
+    /// output would make every embedding already on disk undecryptable, and it
+    /// fails here first. AES-256-GCM is a fixed standard, so a correct 0.11
+    /// implementation must reproduce these exact bytes.
+    #[test]
+    fn test_aes256gcm_known_answer_vector() {
+        let key = Key::<Aes256Gcm>::from_slice(&[0u8; 32]);
+        let cipher = Aes256Gcm::new(key);
+        let nonce = Nonce::from_slice(&[0u8; 12]);
+        let out = cipher.encrypt(nonce, [0u8; 16].as_slice()).unwrap();
+
+        let expected_ciphertext = [
+            0xce, 0xa7, 0x40, 0x3d, 0x4d, 0x60, 0x6b, 0x6e, 0x07, 0x4e, 0xc5, 0xd3, 0xba, 0xf3,
+            0x9d, 0x18,
+        ];
+        let expected_tag = [
+            0xd0, 0xd1, 0xc8, 0xa7, 0x99, 0x99, 0x6b, 0xf0, 0x26, 0x5b, 0x98, 0xb5, 0xd4, 0x8a,
+            0xb9, 0x19,
+        ];
+        assert_eq!(out.len(), 32, "ciphertext+tag length changed");
+        assert_eq!(
+            &out[..16],
+            &expected_ciphertext,
+            "AES-256-GCM ciphertext drifted from NIST vector"
+        );
+        assert_eq!(
+            &out[16..],
+            &expected_tag,
+            "AES-256-GCM tag drifted from NIST vector"
+        );
+    }
+
+    /// Locks the on-disk embedding blob format — a 12-byte nonce prefix followed
+    /// by AES-256-GCM ciphertext + 16-byte tag — and confirms AEAD authentication
+    /// (any tag tamper is rejected, i.e. decryption fails closed). Together with
+    /// the KAT above this guards the storage contract across `aes-gcm` upgrades.
+    #[tokio::test]
+    async fn test_encrypted_blob_format_and_authentication() {
+        let store = FaceModelStore {
+            conn: tokio_rusqlite::Connection::open(Path::new(":memory:"))
+                .await
+                .unwrap(),
+            enc_key: [7u8; 32],
+        };
+        let values: Vec<f32> = (0..EMBEDDING_DIM).map(|i| i as f32 / 512.0).collect();
+
+        let blob = store.encrypt_embedding(&values).unwrap();
+        // 12-byte nonce + 2048-byte plaintext + 16-byte GCM tag.
+        assert_eq!(blob.len(), 12 + EMBEDDING_BYTE_LEN + 16);
+
+        // Round-trips bit-exactly through the current format.
+        let out = store.decrypt_embedding(&blob).unwrap();
+        assert_eq!(out.len(), EMBEDDING_DIM);
+        for (a, b) in values.iter().zip(out.iter()) {
+            assert_eq!(a.to_bits(), b.to_bits());
+        }
+
+        // Flipping the final tag byte must fail authentication (fail closed).
+        let mut tampered = blob.clone();
+        let last = tampered.len() - 1;
+        tampered[last] ^= 0x01;
+        assert!(store.decrypt_embedding(&tampered).is_err());
+    }
+
     #[tokio::test]
     async fn test_list_by_user() {
         let store = FaceModelStore::open(Path::new(":memory:")).await.unwrap();


### PR DESCRIPTION
## What problem does this solve?

A security-hardening pass over `visaged`'s authorization and runtime surface. Four issues, all defense-in-depth or fail-open → fail-closed corrections:

1. **The privileged D-Bus methods (`Enroll`, `RemoveModel`, `ListModels`) were root-only by the system-bus policy file alone.** A missing, mis-scoped, or overly-permissive `org.freedesktop.Visage1.conf` — or running on the session bus — could let a non-root caller reach enrollment mutation or the enrollment listing. `Verify` already validated the caller UID in-process; these did not.
2. **`VISAGE_SESSION_BUS=0` enabled session-bus mode** (which *skips* caller-UID validation). The flag was read with `env::var(..).is_ok()`, so any value — including `0`, the natural way to turn it off — enabled it: a fail-open trap.
3. **Passive liveness failed open on thin data.** `check_landmark_stability` returned "live" when fewer than two landmark frames were available, so a match backed by a single detectable landmark frame bypassed the liveness gate.
4. **`zbus` ran on its default `async-io` executor** while `visaged` awaits tokio primitives inside `#[zbus::interface]` handlers — a latent "no reactor running" panic if a reactor-bound tokio call is ever added, and a transitive dep could silently revert the whole process to `async-io`.

## What changed

- **Root-only in-handler check** on `Enroll`/`RemoveModel`/`ListModels` (`require_root_caller`), skipped on the session bus, mirroring `Verify`.
- **`parse_session_bus`**: only a non-empty, non-`"0"` value opts in; unset/empty/`"0"` keep the secure system-bus default. Unit-tested.
- **Liveness fails closed** on `< 2` landmark frames; surfaced as a rate-limited non-match. `frames_per_verify` defaults to 3, so a live subject in normal lighting is unaffected.
- **Pinned `zbus` to `tokio`** (`default-features = false, features = ["tokio"]`; `pam-visage` re-adds `blocking-api`, which runs on zbus's internal tokio runtime). Drops the `async-io`/`smol` stack from the tree.
- **AES-256-GCM NIST known-answer test + blob-format guard** so a future `aes-gcm` upgrade can't silently change the on-disk format and orphan enrollments.

No public API or D-Bus wire-format changes (the `#[zbus(header)]`/`#[zbus(connection)]` params are injected, not part of the wire signature). Bumps to **v0.3.6**.

## Testing

In the nix devshell: `cargo build`, `cargo test` (79 tests, incl. new session-bus, liveness fail-closed, and crypto KAT/blob-format cases), `cargo clippy --workspace -- -D warnings`, and `cargo fmt --all -- --check` — all clean. `cargo tree -e features` confirms `zbus` no longer pulls `async-io`.
