### PR TITLE
docs: reflect v0.3.6 across README, STATUS, STRATEGY

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Linux-PAM — no kernel patches, no modified sudo.
 
 ## Status
 
-**v0.3.5 — feature-complete, end-to-end tested on Ubuntu 24.04.4 LTS.**
+**v0.3.6 — feature-complete, end-to-end tested on Ubuntu 24.04.4 LTS.**
 
 All 6 implementation steps complete. Verified: enroll, verify, PAM/sudo integration,
 systemd hardening, D-Bus access control, install/remove/purge lifecycle, suspend/resume.
@@ -27,7 +27,9 @@ Since v0.3.3: fixed capture degradation on shared webcams (per-capture format re
 in-process camera self-heal), added IR-emitter coverage for the HP OmniBook X Flip and
 Lenovo ThinkBook 14, enabled Dependabot security updates + a scheduled `cargo audit`, and
 reframed contribution review around the problem a PR solves (see [CONTRIBUTING](CONTRIBUTING.md)).
-See [CHANGELOG](CHANGELOG.md) for the full history.
+v0.3.6 hardened the D-Bus authorization surface (in-process root checks on the privileged
+methods; the session-bus flag and passive liveness now fail closed) and pinned the async
+executor to tokio. See [CHANGELOG](CHANGELOG.md) for the full history.
 
 | Step | Component | Status |
 |------|-----------|--------|
@@ -90,7 +92,7 @@ the [Operations Guide](docs/operations-guide.md).
 ### Ubuntu / Debian (.deb)
 
 ```bash
-sudo apt install ./visage_0.3.5_amd64.deb
+sudo apt install ./visage_0.3.6_amd64.deb
 sudo visage setup                          # download ONNX models (~182 MB)
 sudo visage enroll --label default         # enroll your face
 sudo echo "face auth works"                # test — face first, password fallback

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Visage v0.3 Release Status
 
 **Last updated:** 2026-07-07
-**Build state:** v0.3.5 shipped. All 6 implementation steps complete + model integrity enforcement + OSS governance + passive liveness detection. Since v0.3.3: fixed capture degradation on shared webcams (per-capture V4L2 format re-assert + in-process camera self-heal, #48); the IR emitter quirks DB now covers ASUS Zenbook 14 UM3406HA, Lenovo ThinkPad X1 Carbon Gen 9, Lenovo ThinkBook 14 MP2PQAZG, and HP OmniBook X Flip; NixOS flake build fixed; Dependabot security updates + a scheduled `cargo audit` enabled; contribution review reframed problem-first (ADR 010 §9). End-to-end tested on Ubuntu 24.04.4 LTS. Passive liveness still awaits manual spoof testing on hardware.
+**Build state:** v0.3.6 shipped. All 6 implementation steps complete + model integrity enforcement + OSS governance + passive liveness detection. Since v0.3.3: fixed capture degradation on shared webcams (per-capture V4L2 format re-assert + in-process camera self-heal, #48); the IR emitter quirks DB now covers ASUS Zenbook 14 UM3406HA, Lenovo ThinkPad X1 Carbon Gen 9, Lenovo ThinkBook 14 MP2PQAZG, and HP OmniBook X Flip; NixOS flake build fixed; Dependabot security updates + a scheduled `cargo audit` enabled; contribution review reframed problem-first (ADR 010 §9). v0.3.6 added a security hardening batch: in-process root checks on the privileged D-Bus methods (`Enroll`/`RemoveModel`/`ListModels`), the `VISAGE_SESSION_BUS` flag and passive liveness now fail closed, `zbus` pinned to the tokio executor (drops the `async-io` stack), and an AES-256-GCM known-answer + blob-format test. End-to-end tested on Ubuntu 24.04.4 LTS. Passive liveness still awaits manual spoof testing on hardware.
 
 ---
 

--- a/docs/STRATEGY.md
+++ b/docs/STRATEGY.md
@@ -1,7 +1,7 @@
 # Visage Strategy
 
 **Status:** Living — reflects committed direction. Updated as versions ship.
-**Last reviewed:** 2026-02-24
+**Last reviewed:** 2026-07-07
 
 ---
 
@@ -32,9 +32,9 @@ Linux deserves a biometric authentication layer that is **reliable, secure, and 
 
 ---
 
-## Where We Are: v0.3.5
+## Where We Are: v0.3.6
 
-**Shipped 2026-05-28 (v0.3.3) and 2026-07-07 (v0.3.4, v0.3.5), on top of the v0.3.0 foundation.**
+**Shipped 2026-05-28 (v0.3.3) and 2026-07-07 (v0.3.4, v0.3.5, v0.3.6), on top of the v0.3.0 foundation.**
 
 v0.3.0 (2026-02-23) shipped all 6 implementation steps end-to-end on Ubuntu 24.04.4 LTS.
 The v0.3.x point releases since then addressed two silent ship-time bugs and added
@@ -60,6 +60,13 @@ broader hardware + packaging coverage:
   write) and the Lenovo ThinkBook 14 MP2PQAZG (`30c9:00c2`); `openssl` + `rustls-webpki`
   security bumps (Dependabot security updates now enabled). Contribution review reframed
   problem-first (a PR is a "push request" — ADR 010 §9).
+- **v0.3.6 (2026-07-07)** — security hardening batch. In-process root checks on the
+  privileged D-Bus methods (`Enroll`/`RemoveModel`/`ListModels`) — defense-in-depth over
+  the system-bus policy file alone; `VISAGE_SESSION_BUS=0` no longer fail-opens session-bus
+  mode (which skips UID validation); passive liveness fails closed on insufficient landmark
+  data; `zbus` pinned to the tokio executor (drops the `async-io`/`smol` stack, closes a
+  latent reactor-panic class); AES-256-GCM known-answer + on-disk blob-format test. No
+  public API or D-Bus wire-format changes.
 
 | Component | What it delivers |
 |-----------|-----------------|


### PR DESCRIPTION
The "current version" doc surfaces still said v0.3.5, predating the v0.3.6 security hardening batch. Bumps README Status (+ one-line hardening summary + .deb example), docs/STATUS.md build state, and docs/STRATEGY.md (v0.3.6 release entry, "Where We Are" header, review date). Docs-only; no code or product change.