### PR TITLE
fix(ci): tag-trigger the release job, and refuse to publish an assetless release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 
@@ -81,7 +82,16 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     needs: build-deb
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'release:')
+    # Tag-triggered, deliberately.
+    #
+    # This previously gated on the head commit message starting with "release:".
+    # That stopped matching when the repo adopted Conventional Commits
+    # ("chore(release): 0.3.4"), and nothing reported a failure: v0.3.4, v0.3.5
+    # and v0.3.6 were all published by hand with no .deb attached, and each one
+    # looked correct. A commit-message convention should never be load-bearing
+    # for a release. A tag is explicit and no convention can silently sever it.
+    # See issue #75.
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:
@@ -92,16 +102,57 @@ jobs:
         with:
           name: visage-deb
 
-      - name: Get version
+      - name: Resolve version and verify it matches the tag
         id: version
-        run: echo "version=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#v}"
+          manifest="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')"
+          if [ "$tag" != "$manifest" ]; then
+            echo "::error::tag v${tag} does not match Cargo.toml version ${manifest}"
+            exit 1
+          fi
+          echo "version=${tag}" >> "$GITHUB_OUTPUT"
+          # SemVer: a pre-release is a version carrying a hyphenated suffix.
+          case "$tag" in
+            *-*) echo "prerelease=true"  >> "$GITHUB_OUTPUT" ;;
+            *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Extract this version's changelog section
+        run: |
+          set -euo pipefail
+          v="${{ steps.version.outputs.version }}"
+          awk -v tag="v${v}" '
+            $1 == "##" && $2 == tag { f = 1; next }
+            f && $1 == "##"         { exit }
+            f                       { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::error::CHANGELOG.md has no '## v${v}' section"
+            exit 1
+          fi
+
+      - name: Verify a .deb is actually present
+        run: |
+          set -euo pipefail
+          found=0
+          for deb in visage_*.deb; do
+            [ -e "$deb" ] || continue
+            found=1
+            printf '  %s (%s bytes)\n' "$deb" "$(stat -c %s "$deb")"
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::no visage_*.deb to attach — refusing to publish an assetless release"
+            exit 1
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: v${{ steps.version.outputs.version }}
+          tag_name: ${{ github.ref_name }}
           name: Visage v${{ steps.version.outputs.version }}
-          body_path: CHANGELOG.md
+          body_path: RELEASE_NOTES.md
           files: visage_*.deb
           draft: false
-          prerelease: true
+          prerelease: ${{ steps.version.outputs.prerelease }}


### PR DESCRIPTION
## The problem

`v0.3.4`, `v0.3.5` and `v0.3.6` were all published with **zero release assets**. #75 reports the user-visible half: there is no `.deb` to download.

The root cause is the release job's gate:

```yaml
if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'release:')
```

Correlation across every release is exact:

| tag | assets | head commit | matches gate |
|---|---|---|---|
| v0.3.2 | 1 | `release: v0.3.2 (#34)` | yes |
| v0.3.3 | 1 | `release: v0.3.3 (#35)` | yes |
| v0.3.4 | 0 | `chore(release): 0.3.4 (#58)` | no |
| v0.3.5 | 0 | `chore(release): 0.3.5 (#61)` | no |
| v0.3.6 | 0 | `harden: ... (v0.3.6) (#64)` | no |

The repo adopted Conventional Commits — which is the better convention — and that silently disabled its own release pipeline. Nothing failed, because each GitHub release was then created by hand and looked correct. 30 commits and 47 days of work have not reached a single user, including the `bindgenHook` fix for #69, `visage onboard`, the first externally contributed hardware quirk, and ten dependency bumps.

## The fix

Trigger on tag push rather than on a commit-message prefix. A commit convention should never be load-bearing for a release.

Four supporting changes so this class of silent failure cannot recur:

- **Assert the tag matches `Cargo.toml`'s version.** An artifact cannot ship under a label that disagrees with the tree it was built from.
- **Refuse to publish when no `.deb` is present.** The exact failure this PR fixes becomes a red build instead of a quiet omission.
- **Extract only this version's CHANGELOG section** for the release body, rather than attaching the whole changelog to every release.
- **Derive `prerelease` from the version string** instead of hardcoding `true`.

## Verification

- `actionlint` exit 0, no findings.
- Changelog extraction tested against the real `v0.3.6` section — 48 lines, stops correctly at the next heading — and against a nonexistent version, which yields empty and trips the `exit 1`.
- The asset guard proven in both directions under bash: `found=0` with no `.deb` present, `found=1` with one.

Not verified by this PR: an end-to-end tag-triggered run. That happens the first time a `v*` tag is pushed, which is the release cut this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
