### PR TITLE
fix(security): enforce the daemon's network isolation instead of asserting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,23 @@
   sudo. The help text on `enroll`, `verify`, `list` and `remove` said "defaults to
   `$USER`" and has been corrected too.
 
+### Security
+
+- **The daemon's network isolation is now enforced, not merely asserted.**
+  `threat-model.md` justifies its largest documented hardening gap —
+  `MemoryDenyWriteExecute=false`, required by ONNX Runtime's JIT — by stating
+  that the daemon "has no network access, no inbound connections". No unit
+  directive enforced that, so the compensating control for that exception did
+  not exist. Reported as issue #78.
+
+  `visaged.service` now sets `PrivateNetwork=true` in both the packaged unit
+  and the NixOS module, placing the daemon in its own network namespace with
+  loopback only. `visaged` makes no network calls of its own; the only HTTP
+  client in the workspace is `ureq`, used solely by `visage-cli` for `visage
+  setup` model downloads, which runs as a separate process and is unaffected.
+  D-Bus is an AF_UNIX filesystem socket and is not namespaced by
+  `PrivateNetwork`.
+
 ### Notes
 
 - `nix build .#visage` now succeeds end-to-end: compile, unit tests, and install of

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -62,12 +62,20 @@ The packaging step added systemic hardening beyond the core auth logic:
 | `PrivateTmp=true` | Isolated `/tmp` — prevents `/tmp` race attacks |
 | `CapabilityBoundingSet=` (empty) | All Linux capabilities dropped — root with no capabilities |
 | `DeviceAllow=char-video4linux rw` | Camera access is the only device permission |
+| `PrivateNetwork=true` | Own network namespace, loopback only — the daemon cannot reach the network |
 | `MemoryDenyWriteExecute=false` | Intentionally disabled — ONNX Runtime requires W+X for JIT |
 
 The `MemoryDenyWriteExecute=false` exception is the most significant hardening gap. It allows
 the daemon to map writable+executable memory pages, which ONNX Runtime requires for its CPU
-execution provider JIT compilation. Mitigations: the daemon has no network access, no inbound
-connections, and is further sandboxed by all other directives.
+execution provider JIT compilation. Mitigations: the daemon has no network access — enforced by
+`PrivateNetwork=true`, which places it in its own network namespace with loopback only — and it
+is further sandboxed by all other directives.
+
+Until v0.4 that network claim was an assertion with nothing behind it: no unit directive
+enforced isolation, so the compensating control this exception is justified by did not exist.
+Reported as issue #78 and now enforced. The daemon makes no network calls of its own; the only
+HTTP client in the workspace is `ureq`, used solely by `visage-cli` for `visage setup` model
+downloads, which runs as a separate process and is unaffected.
 
 ### D-Bus Policy
 
@@ -119,7 +127,9 @@ require structured journal fields (sd_journal_send) rather than plain syslog —
    caller UNIX UID against the target username, but it does not yet use
    `GetConnectionCredentials`.
 
-3. **Root daemon with W+X pages.** `MemoryDenyWriteExecute=false` weakens sandbox.
+3. **Root daemon with W+X pages.** `MemoryDenyWriteExecute=false` weakens sandbox. The
+   compensating control is `PrivateNetwork=true` (added in v0.4; see issue #78), which denies
+   the daemon any route off the host.
 
 4. **Passive liveness threshold is tunable.** `VISAGE_LIVENESS_MIN_DISPLACEMENT` defaults
    to 0.8 px. Cameras with very low frame rates or high sensor noise may require adjustment.

--- a/packaging/nix/module.nix
+++ b/packaging/nix/module.nix
@@ -298,6 +298,11 @@ in
         ReadWritePaths = [ "/var/lib/visage" ];
         CapabilityBoundingSet = "";
         SystemCallArchitectures = "native";
+        # Enforces the "no network access" claim threat-model.md relies on to
+        # justify MemoryDenyWriteExecute=false. See issue #78 and the comment
+        # in packaging/systemd/visaged.service. visaged makes no network calls;
+        # `ureq` lives only in visage-cli, for `visage setup`.
+        PrivateNetwork = true;
         MemoryDenyWriteExecute = false;
       };
     };

--- a/packaging/systemd/visaged.service
+++ b/packaging/systemd/visaged.service
@@ -27,6 +27,14 @@ DeviceAllow=char-video4linux rw
 ReadWritePaths=/var/lib/visage
 CapabilityBoundingSet=
 SystemCallArchitectures=native
+# threat-model.md justifies MemoryDenyWriteExecute=false by stating the daemon
+# "has no network access, no inbound connections". Nothing enforced that until
+# now (issue #78), so the compensating control for the largest documented
+# hardening gap did not exist. visaged makes no network calls — the only HTTP
+# client in the workspace is `ureq`, used solely by visage-cli for `visage
+# setup` model downloads, which is a separate process and unaffected. D-Bus is
+# an AF_UNIX filesystem socket and is not namespaced by PrivateNetwork.
+PrivateNetwork=true
 MemoryDenyWriteExecute=false
 
 [Install]


### PR DESCRIPTION
Closes #78.

## The claim, and what was behind it

`docs/threat-model.md` justifies the project's largest documented hardening gap — `MemoryDenyWriteExecute=false`, which ONNX Runtime's JIT requires — like this:

> The `MemoryDenyWriteExecute=false` exception is the most significant hardening gap. … **Mitigations: the daemon has no network access, no inbound connections**, and is further sandboxed by all other directives.

Nothing enforced it. Neither `packaging/systemd/visaged.service` nor `packaging/nix/module.nix` carried `PrivateNetwork`, `IPAddressDeny` or `RestrictAddressFamilies`, and a live service on a running host confirms it:

```
PrivateNetwork=no
IPAddressDeny=
RestrictAddressFamilies=~
ProtectSystem=strict      <- control: the directives the doc DOES claim are present
NoNewPrivileges=yes
```

So the compensating control that the exception is justified by did not exist. A root daemon able to map W+X pages could also reach the network — a materially different risk from the one the document describes. @RedHatOnTop was right.

## The fix

Both systemd definitions now set `PrivateNetwork=true`, placing visaged in its own network namespace with loopback only.

This is safe because **visaged makes no network calls**. The only HTTP client in the workspace is `ureq`, and it appears in exactly one crate:

```
crates/visage-cli/Cargo.toml:24:ureq = "3"     <- the only one
crates/visage-cli/src/setup.rs                 <- the only user
```

That is `visage setup`'s model download, a separate process, unaffected by the daemon's namespace. D-Bus is an AF_UNIX filesystem socket and is not namespaced by `PrivateNetwork`.

`threat-model.md` is updated in three places — the sandbox directive table, the `MemoryDenyWriteExecute` justification (which now names what enforces it), and the known-gaps entry. The doc also records that the claim was previously unenforced rather than quietly becoming true, because a reader who relied on it deserves to know it did not hold.

## Verification

- `systemd-analyze verify` exits 0 with no complaint about the new directive.
- The NixOS module parses.
- `ureq` confinement to `visage-cli` confirmed with a control (the grep finds the CLI's use, so its silence on `visaged` is meaningful).

**Not verified:** that visaged runs correctly under `PrivateNetwork` at runtime. That requires root and restarting a live authentication daemon, which was not available in this session. The reasoning above is static, and a runtime check on any host running visaged is one `systemctl restart visaged && visage verify` away.

## Not addressed

`RestrictAddressFamilies=AF_UNIX` would be defense in depth on top of this, but it can break subtle things (netlink use by dependencies) and was not testable here, so it is deliberately left out rather than shipped untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
