### PR TITLE
ci: pin the toolchain, and watch stable in a job that cannot block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,25 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpam0g-dev libdbus-1-dev
 
+      - name: Read the pinned toolchain
+        id: rust
+        run: |
+          set -euo pipefail
+          channel="$(grep '^channel' rust-toolchain.toml | sed 's/.*"\(.*\)"/\1/')"
+          # Refuse rather than hand the action an empty string, which it would
+          # silently resolve to something else.
+          if [ -z "$channel" ]; then
+            echo "::error::no channel found in rust-toolchain.toml"
+            exit 1
+          fi
+          echo "using pinned toolchain: ${channel}"
+          echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust.outputs.channel }}
+          components: clippy, rustfmt
 
       - name: Cache cargo registry and build
         uses: actions/cache@v6
@@ -52,8 +69,25 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpam0g-dev libdbus-1-dev
 
+      - name: Read the pinned toolchain
+        id: rust
+        run: |
+          set -euo pipefail
+          channel="$(grep '^channel' rust-toolchain.toml | sed 's/.*"\(.*\)"/\1/')"
+          # Refuse rather than hand the action an empty string, which it would
+          # silently resolve to something else.
+          if [ -z "$channel" ]; then
+            echo "::error::no channel found in rust-toolchain.toml"
+            exit 1
+          fi
+          echo "using pinned toolchain: ${channel}"
+          echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust.outputs.channel }}
+          components: clippy, rustfmt
 
       - name: Cache cargo registry and build
         uses: actions/cache@v6
@@ -156,3 +190,34 @@ jobs:
           files: visage_*.deb
           draft: false
           prerelease: ${{ steps.version.outputs.prerelease }}
+
+  clippy-latest:
+    # Non-blocking early warning for toolchain drift.
+    #
+    # The jobs above are pinned (rust-toolchain.toml), so a new clippy release
+    # can no longer halt the repository the way it did on 2026-08-24 — identical
+    # commit, green on 08-18, red on 08-24, purely because @stable floated.
+    #
+    # Pinning alone would trade that failure for a slower one: lints would
+    # accumulate unseen until someone bumped the pin. This job keeps the early
+    # warning without the blocking property. `continue-on-error` means it cannot
+    # fail the workflow, and it is not in the required status checks, so a red
+    # result here is information rather than a gate.
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpam0g-dev libdbus-1-dev
+
+      - name: Install current stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Report the toolchain being tested
+        run: cargo clippy --version
+
+      - name: Clippy on current stable
+        run: cargo clippy --workspace -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,28 @@
   sudo. The help text on `enroll`, `verify`, `list` and `remove` said "defaults to
   `$USER`" and has been corrected too.
 
+### Developer experience
+
+- **Releases are cut from tags again, and cannot publish empty.** v0.3.4, v0.3.5
+  and v0.3.6 shipped with no `.deb` attached (issue #75). The release job gated
+  on the head commit message starting with `release:`, and adopting Conventional
+  Commits (`chore(release): 0.3.4`) silently severed it — nothing failed,
+  because each release was then created by hand and looked correct. The job is
+  now triggered by a `v*` tag, asserts the tag matches `Cargo.toml`, attaches
+  only that version's changelog section rather than the whole file, derives
+  pre-release status from the version string, and refuses to publish at all if
+  no `.deb` is present.
+
+- **The toolchain is pinned, so CI cannot change behaviour without a commit.**
+  The identical commit passed CI on 2026-08-18 and failed on 2026-08-24, purely
+  because `dtolnay/rust-toolchain@stable` floated onto a compiler whose clippy
+  added a new lint; with `-D warnings` that halted every merge in the repository
+  for six days. `rust-toolchain.toml` now pins the version — tracking what
+  `nix develop` provides, so a local `cargo clippy` reproduces CI exactly — and
+  the workflow reads it as the single source of truth. A new non-blocking
+  `clippy-latest` job still runs against current stable, so new lints surface
+  early without being able to block a merge.
+
 ### Security
 
 - **The daemon's network isolation is now enforced, not merely asserted.**

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,28 @@
+# Pinned so CI cannot change behaviour without a commit.
+#
+# On 2026-08-24 the identical commit 63c9fbc passed CI on 08-18 and failed on
+# 08-24. Nothing had changed but the toolchain: the workflow resolved
+# `dtolnay/rust-toolchain@stable`, which floated onto a Rust whose clippy adds
+# `chunks_exact_to_as_chunks`. With `-D warnings` that is an instant failure on
+# untouched code, and it blocked every merge in the repository for six days
+# before anyone pushed and noticed.
+#
+# This version deliberately tracks what `nix develop` provides, so that a local
+# `cargo clippy` reproduces CI exactly. That mattered: the lint above could not
+# be reproduced locally while CI was pinned to a newer compiler, which is the
+# worst possible split.
+#
+# There is no guard coupling this file to the flake. If a nixpkgs bump moves the
+# devshell's rustc, re-sync by hand:
+#
+#     nix develop --command rustc --version
+#
+# Drift then makes CI *older* than local, so it surfaces on a developer's
+# machine before a push rather than only in CI — the safe direction.
+#
+# `.github/workflows/ci.yml` reads `channel` from this file; it is the single
+# source of truth. The clippy-latest job there watches current stable without
+# being able to block a merge.
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## CI went red with no commit

The **identical commit** `63c9fbc`:

| when | result |
|---|---|
| 2026-08-18 17:12 | success |
| 2026-08-24 06:51 | **failure** |

Nothing changed but the toolchain. The workflow resolved `dtolnay/rust-toolchain@stable`, which floated onto a Rust whose clippy adds `chunks_exact_to_as_chunks`; with `-D warnings` that is an instant failure on untouched code. It blocked **every merge in the repository for six days** before anyone pushed and noticed — which is the real cost, not the lint.

## What this does

**`rust-toolchain.toml` pins the version**, and both blocking jobs read `channel` from it rather than carrying a second copy that could drift.

**The pinned version deliberately tracks what `nix develop` provides.** That is the point, not an accident. The lint above *could not be reproduced locally* while CI ran a newer compiler — the worst possible split, a red build nobody can investigate on their own machine.

**A new `clippy-latest` job watches current stable.** Pinning alone would trade a fast failure for a slow one, with lints accumulating unseen until someone bumped the pin. This job reports them early, but `continue-on-error: true` means it cannot fail the workflow, and it is not among the required status checks, so a red result there is information rather than a gate.

**The read step refuses on an empty channel** rather than handing the action an empty string it would silently resolve to something else — the same failure shape as the release-trigger bug in #86.

## Verification

- `actionlint` exit 0, no findings.
- The extraction returns `1.95.0` and **matches `nix develop`'s rustc exactly**, so local now reproduces CI.
- Negative control: a toml with no `channel` line yields empty and trips the refusal; the real file is accepted.

## Trade-offs, stated

- **`@master` on the action.** Passing an explicit `toolchain:` requires `dtolnay/rust-toolchain@master` per its own docs — it does not read `rust-toolchain.toml` itself. That is a looser ref than the `@v7`/`@v6` major-version floats already in this workflow. The alternative, `@1.95.0` version branches, would pin the action but duplicate the version into three places; single-source was judged the more important property given that a silently drifting copy is exactly what caused #86.
- **No guard couples this file to the flake.** A nixpkgs bump can still move the devshell's rustc. When it does, drift makes CI *older* than local, so it surfaces on a developer's machine before a push rather than only in CI — the safe direction. Re-sync is documented in the file itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
