### PR TITLE
test: the first integration tests, and a live defect the first one found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,34 @@
   `$USER`" and has been corrected too.
 
 ### Developer experience
+- **The first integration tests.** `crates/visaged/tests/` — 12 hermetic tests, plus 3
+  hardware tests that CI skips. Added because **both of the worst bugs in this project's
+  history were structurally invisible to unit tests**: `success=end`, an invalid PAM control
+  keyword that libpam silently treats as `ignore`, which made face auth a no-op on the
+  documented setup path from v0.1.0 to v0.3.2; and the V4L2 format cache (#48). Neither was a
+  logic error in a function — both were contracts *between artifacts*, which is the seam a
+  unit test cannot reach.
+
+  `pam_control_contract` asserts the control string is a valid libpam control and identical
+  across the Debian, Arch and NixOS packaging — it rejects `success=end` by name.
+  `systemd_hardening_contract` asserts every directive `threat-model.md` claims exists in
+  **both** systemd definitions, which is issue #78's class generalised.
+  `packaging_paths_contract` asserts the deb ships artifacts the workspace actually builds and
+  that `ExecStart` matches the install path. `dbus_contract` asserts the interface the daemon
+  serves is the one its three independently-compiled clients call — a rename there currently
+  compiles clean and breaks only at an authentication prompt.
+
+  Hermetic: no hardware, no root, no D-Bus, no models, **no new dependencies**, and no CI
+  changes — `cargo test --workspace` already picks them up. Each guard was proven to fail on
+  the defect it exists for before being committed.
+
+- **Fixed: `TimeoutStopSec` was missing from the NixOS module.** Found by the new
+  `systemd_hardening_contract`, which failed on the tree as it stood. The directive was added
+  for #26 to bound a stuck v4l2 capture on `systemctl stop|restart`, cutting a ~90s
+  post-hibernate hang to ~10s. It was present in the Debian unit only, so **NixOS hosts never
+  got the fix** — a running host reported systemd's 90s default, exactly the hang it was meant
+  to remove.
+
 
 - **Releases are cut from tags again, and cannot publish empty.** v0.3.4, v0.3.5
   and v0.3.6 shipped with no `.deb` attached (issue #75). The release job gated

--- a/crates/visaged/tests/daemon_lifecycle.rs
+++ b/crates/visaged/tests/daemon_lifecycle.rs
@@ -1,0 +1,223 @@
+//! End-to-end lifecycle: launch the real `visaged` and drive it over D-Bus.
+//!
+//! **Ignored by default. This needs a camera.**
+//!
+//! ```text
+//! cargo test -p visaged --test daemon_lifecycle -- --ignored --nocapture
+//! ```
+//!
+//! `spawn_engine` opens the camera and loads the ONNX models synchronously
+//! before the daemon serves D-Bus (`crates/visaged/src/engine.rs`), so there is
+//! no headless path — the daemon cannot start without hardware. Rather than
+//! depend on a virtual V4L2 device in CI, which would be another
+//! externally-maintained thing that can silently break the build, this runs on a
+//! real machine with a real IR camera. That is also higher fidelity.
+//!
+//! Everything it needs is steerable by environment (`crates/visaged/src/config.rs`):
+//!
+//! | var | default | meaning |
+//! |---|---|---|
+//! | `VISAGE_TEST_CAMERA` | `/dev/video2` | capture device |
+//! | `VISAGE_TEST_MODEL_DIR` | `/var/lib/visage/models` | ONNX models |
+//!
+//! The daemon runs on a **private session bus** this test spawns, with a
+//! temporary database, so it never touches the system bus, the real store, or a
+//! running production `visaged`.
+//!
+//! # What this covers that no unit test can
+//!
+//! Startup ordering, the model-integrity gate, D-Bus name registration, method
+//! dispatch across the wire, store open, and — the one that matters most —
+//! that a client call **fails promptly rather than hanging** when the daemon is
+//! gone. `pam-visage`'s entire contract is that it never blocks a login; a hang
+//! there is an unbootable machine, and nothing in the unit tests exercises it.
+
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+const BUS_NAME: &str = "org.freedesktop.Visage1";
+const OBJECT_PATH: &str = "/org/freedesktop/Visage1";
+const INTERFACE: &str = "org.freedesktop.Visage1";
+
+fn camera() -> String {
+    std::env::var("VISAGE_TEST_CAMERA").unwrap_or_else(|_| "/dev/video2".to_string())
+}
+
+fn model_dir() -> String {
+    std::env::var("VISAGE_TEST_MODEL_DIR").unwrap_or_else(|_| "/var/lib/visage/models".to_string())
+}
+
+/// A private session bus plus a `visaged` attached to it.
+///
+/// Both children are killed on drop, including on panic, so a failing assertion
+/// cannot leave a stray daemon holding a camera.
+struct Fixture {
+    bus: Child,
+    daemon: Child,
+    address: String,
+    db_dir: PathBuf,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = self.daemon.kill();
+        let _ = self.daemon.wait();
+        let _ = self.bus.kill();
+        let _ = self.bus.wait();
+        let _ = std::fs::remove_dir_all(&self.db_dir);
+    }
+}
+
+impl Fixture {
+    fn start() -> Self {
+        let mut bus = Command::new("dbus-daemon")
+            .args(["--session", "--print-address", "--nofork"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect(
+                "cannot spawn `dbus-daemon` — this test needs it to create a private session \
+                 bus. It is deliberately not skipped: you ran it with --ignored on purpose.",
+            );
+
+        let address = {
+            let stdout = bus.stdout.take().expect("dbus-daemon stdout");
+            let mut line = String::new();
+            BufReader::new(stdout)
+                .read_line(&mut line)
+                .expect("dbus-daemon should print its address");
+            line.trim().to_string()
+        };
+        assert!(
+            !address.is_empty(),
+            "dbus-daemon printed an empty bus address"
+        );
+
+        let db_dir = std::env::temp_dir().join(format!("visage-it-{}", std::process::id()));
+        std::fs::create_dir_all(&db_dir).expect("create temp db dir");
+
+        let daemon = Command::new(env!("CARGO_BIN_EXE_visaged"))
+            .env("DBUS_SESSION_BUS_ADDRESS", &address)
+            .env("VISAGE_SESSION_BUS", "1")
+            .env("VISAGE_DB_PATH", db_dir.join("faces.db"))
+            .env("VISAGE_CAMERA_DEVICE", camera())
+            .env("VISAGE_MODEL_DIR", model_dir())
+            .env("RUST_LOG", "visaged=info")
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn visaged");
+
+        Fixture {
+            bus,
+            daemon,
+            address,
+            db_dir,
+        }
+    }
+
+    /// Connect once the daemon has claimed the bus name, or fail with why.
+    async fn connect(&self) -> zbus::Connection {
+        let conn = zbus::connection::Builder::address(self.address.as_str())
+            .expect("valid bus address")
+            .build()
+            .await
+            .expect("connect to the private session bus");
+
+        let dbus = zbus::fdo::DBusProxy::new(&conn).await.expect("DBusProxy");
+        for _ in 0..100 {
+            let names = dbus.list_names().await.expect("list bus names");
+            if names.iter().any(|n| n.as_str() == BUS_NAME) {
+                return conn;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        panic!(
+            "`{BUS_NAME}` never appeared on the bus within 10s. The daemon opens the camera \
+             ({}) and verifies models in {} before serving D-Bus, so a failure here is most \
+             likely one of those — check the stderr above.",
+            camera(),
+            model_dir()
+        );
+    }
+
+    async fn call(
+        &self,
+        conn: &zbus::Connection,
+        method: &str,
+        body: &(impl serde::Serialize + zbus::zvariant::DynamicType),
+    ) -> zbus::Result<zbus::Message> {
+        conn.call_method(Some(BUS_NAME), OBJECT_PATH, Some(INTERFACE), method, body)
+            .await
+    }
+}
+
+#[tokio::test]
+#[ignore = "needs a camera; run with --ignored on a machine that has one"]
+async fn the_daemon_claims_its_bus_name_and_answers_status() {
+    let fx = Fixture::start();
+    let conn = fx.connect().await;
+
+    let reply = fx
+        .call(&conn, "Status", &())
+        .await
+        .expect("Status should succeed");
+    let status: String = reply.body().deserialize().expect("Status returns a string");
+
+    assert!(
+        !status.trim().is_empty(),
+        "Status returned an empty string; the daemon is on the bus but not reporting state"
+    );
+    eprintln!("visaged status: {status}");
+}
+
+#[tokio::test]
+#[ignore = "needs a camera; run with --ignored on a machine that has one"]
+async fn verify_for_an_unenrolled_user_returns_false_rather_than_erroring() {
+    let fx = Fixture::start();
+    let conn = fx.connect().await;
+
+    // A user that cannot have an enrolment.
+    let unknown = format!("visage-it-nobody-{}", std::process::id());
+    let reply = fx.call(&conn, "Verify", &(unknown.as_str(),)).await.expect(
+        "Verify on an unenrolled user must return a value, not a D-Bus error. pam-visage \
+             treats an error the same as a non-match, so this distinction is invisible at the \
+             PAM layer and must be asserted here.",
+    );
+    let matched: bool = reply.body().deserialize().expect("Verify returns a bool");
+
+    assert!(!matched, "an unenrolled user must not match");
+}
+
+#[tokio::test]
+#[ignore = "needs a camera; run with --ignored on a machine that has one"]
+async fn a_client_call_fails_promptly_once_the_daemon_is_gone() {
+    let mut fx = Fixture::start();
+    let conn = fx.connect().await;
+
+    // Prove the connection works before we take the daemon away, so a failure
+    // below cannot be blamed on a bad connection.
+    fx.call(&conn, "Status", &())
+        .await
+        .expect("control: Status should succeed while the daemon is alive");
+
+    fx.daemon.kill().expect("kill visaged");
+    fx.daemon.wait().expect("reap visaged");
+
+    // This is pam-visage's core safety property. Its contract is PAM_IGNORE —
+    // fall through to a password — and a hang here is a machine nobody can log
+    // into. The bound is generous; what matters is that it terminates at all.
+    let call = fx.call(&conn, "Status", &());
+    let result = tokio::time::timeout(Duration::from_secs(10), call).await;
+
+    match result {
+        Err(_) => panic!(
+            "a D-Bus call hung for 10s after the daemon exited. pam_visage would block the \
+             authentication stack here rather than falling through to a password."
+        ),
+        Ok(Ok(_)) => panic!("the call succeeded after the daemon was killed — impossible"),
+        Ok(Err(e)) => eprintln!("failed cleanly, as required: {e}"),
+    }
+}

--- a/crates/visaged/tests/dbus_contract.rs
+++ b/crates/visaged/tests/dbus_contract.rs
@@ -1,0 +1,245 @@
+//! Contract: the D-Bus interface the daemon serves is the one its clients call.
+//!
+//! `org.freedesktop.Visage1` is declared in **three places that compile
+//! independently of each other**:
+//!
+//! | role | file |
+//! |---|---|
+//! | server | `crates/visaged/src/dbus_interface.rs` — `#[interface(...)]` |
+//! | CLI client | `crates/visage-cli/src/main.rs` — `#[zbus::proxy(...)]`, 5 methods |
+//! | PAM client | `crates/pam-visage/src/lib.rs` — `#[zbus::proxy(...)]`, 1 method |
+//!
+//! plus the bus name and object path in `crates/visaged/src/main.rs`, and the
+//! system-bus policy in `packaging/dbus/org.freedesktop.Visage1.conf`.
+//!
+//! There is no shared constant. Rename a method on the server and every one of
+//! those still compiles; the break appears only when a real call is made — which
+//! for `pam-visage` means at an authentication prompt, where its contract is to
+//! return `PAM_IGNORE` and fall through to a password. A rename would therefore
+//! present as "face auth stopped working" with a green build, which is the same
+//! shape as the `success=end` bug.
+//!
+//! This test compares the declarations as source. It cannot catch a semantic
+//! change behind an unchanged signature — but it catches the rename, the removed
+//! method, and the drifted interface name, which are the realistic failures.
+
+use std::path::{Path, PathBuf};
+
+const SERVER: &str = "crates/visaged/src/dbus_interface.rs";
+const DAEMON_MAIN: &str = "crates/visaged/src/main.rs";
+const CLI_CLIENT: &str = "crates/visage-cli/src/main.rs";
+const PAM_CLIENT: &str = "crates/pam-visage/src/lib.rs";
+const DBUS_POLICY: &str = "packaging/dbus/org.freedesktop.Visage1.conf";
+
+const INTERFACE: &str = "org.freedesktop.Visage1";
+const OBJECT_PATH: &str = "/org/freedesktop/Visage1";
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/visaged should be two levels below the repo root")
+        .to_path_buf()
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// The `(...)` argument list of `async fn <name>`, paren-balanced so multi-line
+/// signatures work.
+fn arg_list_of(body: &str, name: &str) -> Option<String> {
+    let needle = format!("async fn {name}(");
+    let start = body.find(&needle)? + needle.len();
+    let mut depth = 1usize;
+    for (i, ch) in body[start..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(body[start..start + i].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Arguments that actually cross the wire.
+///
+/// `&self` is not an argument, and zbus injects `#[zbus(header)]` /
+/// `#[zbus(connection)]` parameters locally — they are not part of the D-Bus
+/// signature, so a client legitimately does not declare them.
+fn wire_args(arg_list: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    let mut depth = 0usize;
+    let mut current = String::new();
+    for ch in arg_list.chars() {
+        match ch {
+            '(' | '<' | '[' => {
+                depth += 1;
+                current.push(ch);
+            }
+            ')' | '>' | ']' => {
+                depth = depth.saturating_sub(1);
+                current.push(ch);
+            }
+            ',' if depth == 0 => {
+                args.push(std::mem::take(&mut current));
+            }
+            _ => current.push(ch),
+        }
+    }
+    args.push(current);
+
+    args.into_iter()
+        .map(|a| a.trim().to_string())
+        .filter(|a| !a.is_empty())
+        .filter(|a| a != "&self" && a != "self")
+        .filter(|a| !a.contains("#[zbus("))
+        .collect()
+}
+
+/// Method names declared inside a `#[zbus::proxy]` trait.
+fn proxy_methods(body: &str) -> Vec<String> {
+    let start = match body.find("#[zbus::proxy(") {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    let rest = &body[start..];
+    let brace = match rest.find('{') {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    let end = rest[brace..]
+        .find("\n}")
+        .map(|i| brace + i)
+        .unwrap_or(rest.len());
+    rest[brace..end]
+        .lines()
+        .filter_map(|l| {
+            let t = l.trim();
+            let t = t.strip_prefix("async fn ")?;
+            let name = t.split('(').next()?;
+            Some(name.to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn the_interface_name_and_object_path_agree_everywhere() {
+    let mut missing = Vec::new();
+
+    // The bus name / interface must appear in every site, policy included.
+    for file in [SERVER, DAEMON_MAIN, CLI_CLIENT, PAM_CLIENT, DBUS_POLICY] {
+        if !read(file).contains(INTERFACE) {
+            missing.push(format!("{file}: does not mention `{INTERFACE}`"));
+        }
+    }
+    // The object path is not meaningful in the policy file, which grants by
+    // bus name and interface only.
+    for file in [SERVER, DAEMON_MAIN, CLI_CLIENT, PAM_CLIENT] {
+        let body = read(file);
+        if !body.contains(OBJECT_PATH) {
+            missing.push(format!("{file}: does not mention `{OBJECT_PATH}`"));
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "the D-Bus identity has drifted between the server, its clients and the bus policy. \
+         These compile independently, so a mismatch here is invisible until a real call is \
+         made.\n  {}",
+        missing.join("\n  ")
+    );
+}
+
+#[test]
+fn every_method_a_client_calls_exists_on_the_server_with_the_same_wire_arity() {
+    let server = read(SERVER);
+
+    let clients: &[(&str, Vec<String>)] = &[
+        (CLI_CLIENT, proxy_methods(&read(CLI_CLIENT))),
+        (PAM_CLIENT, proxy_methods(&read(PAM_CLIENT))),
+    ];
+
+    // Vacuity guard: if the proxy parser found nothing, every check below would
+    // pass over an empty set.
+    for (file, methods) in clients {
+        assert!(
+            !methods.is_empty(),
+            "no proxy methods parsed from {file} — the extractor is broken, so a pass here \
+             would mean nothing"
+        );
+    }
+
+    let mut problems = Vec::new();
+    for (file, methods) in clients {
+        for m in methods {
+            match arg_list_of(&server, m) {
+                None => problems.push(format!(
+                    "{file} calls `{m}`, which the server does not declare. This compiles on \
+                     both sides and fails only at runtime."
+                )),
+                Some(server_args) => {
+                    let client_args = arg_list_of(&read(file), m)
+                        .map(|a| wire_args(&a))
+                        .unwrap_or_default();
+                    let server_wire = wire_args(&server_args);
+                    if server_wire.len() != client_args.len() {
+                        problems.push(format!(
+                            "{file} calls `{m}` with {} wire argument(s); the server declares \
+                             {}. server: {server_wire:?} client: {client_args:?}",
+                            client_args.len(),
+                            server_wire.len()
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "client/server D-Bus contract mismatch:\n  {}",
+        problems.join("\n  ")
+    );
+}
+
+/// Control for the parsers above.
+#[test]
+fn the_parsers_can_see_real_declarations() {
+    let server = read(SERVER);
+
+    // Positive: the server really declares `verify`, and it takes one wire arg.
+    let verify = arg_list_of(&server, "verify").expect(
+        "positive control failed — cannot find `async fn verify` in the server, so an empty \
+         result from this parser proves nothing",
+    );
+    let wire = wire_args(&verify);
+    assert_eq!(
+        wire.len(),
+        1,
+        "expected `verify` to take exactly one wire argument (the username); zbus-injected \
+         header/connection params must be filtered out. got: {wire:?}"
+    );
+
+    // Negative: a method that does not exist must not be found.
+    assert!(
+        arg_list_of(&server, "definitely_not_a_method").is_none(),
+        "negative control failed — the parser reports a fabricated method as present"
+    );
+
+    // Both clients must yield methods.
+    assert!(
+        proxy_methods(&read(CLI_CLIENT)).contains(&"verify".to_string()),
+        "positive control failed — the proxy parser cannot see `verify` in the CLI client"
+    );
+    assert!(
+        proxy_methods(&read(PAM_CLIENT)).contains(&"verify".to_string()),
+        "positive control failed — the proxy parser cannot see `verify` in the PAM client"
+    );
+}

--- a/crates/visaged/tests/packaging_paths_contract.rs
+++ b/crates/visaged/tests/packaging_paths_contract.rs
@@ -1,0 +1,229 @@
+//! Contract: the paths the packaging declares are real, and agree with each other.
+//!
+//! `cargo deb` reads an asset list out of `crates/visaged/Cargo.toml`. Nothing
+//! checks that the artifacts it names are ones the workspace actually builds, or
+//! that the files it copies exist, or that the systemd unit's `ExecStart` points
+//! where the package installs the binary. Rename a `[[bin]]` target and the build
+//! stays green; the `.deb` fails at package time, or worse, ships a unit whose
+//! `ExecStart` points at nothing.
+//!
+//! The install locations are also duplicated across three packaging formats with
+//! no shared definition, which is the same drift shape as the PAM control string
+//! (see `pam_control_contract.rs`) and the systemd directives (see
+//! `systemd_hardening_contract.rs`).
+//!
+//! Parsed as text rather than via a TOML crate deliberately: `visaged` has no
+//! dev-dependencies, and these tests are meant to add none.
+
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/visaged should be two levels below the repo root")
+        .to_path_buf()
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// `["source", "dest", "mode"]` rows from `[package.metadata.deb] assets`.
+fn deb_assets() -> Vec<(String, String)> {
+    let manifest = read("crates/visaged/Cargo.toml");
+    let start = manifest
+        .find("assets = [")
+        .expect("crates/visaged/Cargo.toml should declare [package.metadata.deb] assets");
+    let rest = &manifest[start..];
+    let end = rest.find("\n]").expect("assets list should be terminated");
+
+    rest[..end]
+        .lines()
+        .filter_map(|l| {
+            let t = l.trim();
+            if !t.starts_with('[') {
+                return None;
+            }
+            let fields: Vec<_> = t
+                .trim_start_matches('[')
+                .split(',')
+                .map(|f| f.trim().trim_matches(|c| c == '"' || c == ']' || c == ' '))
+                .collect();
+            match fields.as_slice() {
+                [src, dest, ..] => Some((src.to_string(), dest.to_string())),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+/// Filenames the workspace actually produces in `target/release/`.
+fn built_artifact_names() -> Vec<String> {
+    let crates = [
+        "crates/visaged/Cargo.toml",
+        "crates/visage-cli/Cargo.toml",
+        "crates/pam-visage/Cargo.toml",
+        "crates/visage-core/Cargo.toml",
+        "crates/visage-hw/Cargo.toml",
+        "crates/visage-models/Cargo.toml",
+    ];
+    let mut names = Vec::new();
+    for c in crates {
+        let body = read(c);
+        let mut section = String::new();
+        let mut is_cdylib = false;
+        // A second pass is not needed: crate-type appears inside [lib].
+        for line in body.lines() {
+            let t = line.trim();
+            if t.starts_with('[') && t.ends_with(']') {
+                section = t.to_string();
+                continue;
+            }
+            if section == "[lib]" && t.contains("crate-type") && t.contains("cdylib") {
+                is_cdylib = true;
+            }
+        }
+        section.clear();
+        for line in body.lines() {
+            let t = line.trim();
+            if t.starts_with('[') && t.ends_with(']') {
+                section = t.to_string();
+                continue;
+            }
+            let Some(rest) = t.strip_prefix("name = ") else {
+                continue;
+            };
+            let name = rest.trim().trim_matches('"');
+            match section.as_str() {
+                "[[bin]]" => names.push(name.to_string()),
+                "[lib]" if is_cdylib => names.push(format!("lib{name}.so")),
+                _ => {}
+            }
+        }
+    }
+    names
+}
+
+#[test]
+fn every_built_artifact_the_deb_ships_is_one_the_workspace_produces() {
+    let assets = deb_assets();
+    assert!(
+        !assets.is_empty(),
+        "parsed no deb assets — the extractor is broken, so a pass here would mean nothing"
+    );
+
+    let built = built_artifact_names();
+    assert!(
+        built.contains(&"visaged".to_string()),
+        "positive control failed — did not find the `visaged` binary target, so the artifact \
+         list is not trustworthy. found: {built:?}"
+    );
+
+    let mut missing = Vec::new();
+    for (src, _) in &assets {
+        let Some(file) = src.strip_prefix("target/release/") else {
+            continue;
+        };
+        if !built.contains(&file.to_string()) {
+            missing.push(format!(
+                "{src}: the deb ships this, but no crate declares a target producing `{file}`. \
+                 Renaming a [[bin]] leaves the build green and breaks packaging."
+            ));
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "deb asset / build target mismatch:\n  {}",
+        missing.join("\n  ")
+    );
+}
+
+#[test]
+fn every_source_file_the_deb_ships_exists() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut missing = Vec::new();
+    for (src, _) in deb_assets() {
+        if src.starts_with("target/") {
+            continue; // build output, not in the tree
+        }
+        // Asset sources are relative to the manifest directory.
+        if !manifest_dir.join(&src).exists() {
+            missing.push(format!(
+                "{src}: declared in the deb asset list but not present"
+            ));
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "the deb references files that do not exist — `cargo deb` fails at package time, \
+         which is after CI has gone green:\n  {}",
+        missing.join("\n  ")
+    );
+}
+
+#[test]
+fn the_systemd_unit_execstart_points_where_the_deb_installs_the_daemon() {
+    let unit = read("packaging/systemd/visaged.service");
+    let exec = unit
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("ExecStart="))
+        .expect("the unit should declare ExecStart")
+        .split_whitespace()
+        .next()
+        .expect("ExecStart should name a binary")
+        .to_string();
+
+    let dest = deb_assets()
+        .into_iter()
+        .find(|(src, _)| src == "target/release/visaged")
+        .map(|(_, dest)| dest)
+        .expect("the deb should ship the visaged binary");
+
+    // dest is a directory like "usr/bin/"
+    let installed = format!("/{}{}", dest.trim_end_matches('/'), "/visaged");
+    assert_eq!(
+        exec, installed,
+        "the packaged unit's ExecStart ({exec}) does not match where the deb installs the \
+         daemon ({installed}). The package would install a unit that cannot start."
+    );
+}
+
+#[test]
+fn the_pam_module_install_path_agrees_across_packaging_formats() {
+    const SUFFIX: &str = "lib/security/pam_visage.so";
+
+    let deb_dest = deb_assets()
+        .into_iter()
+        .find(|(src, _)| src.ends_with("libpam_visage.so"))
+        .map(|(_, dest)| dest)
+        .expect("the deb should ship the PAM module");
+
+    let aur = read("packaging/aur/PKGBUILD");
+    let nix = read("packaging/nix/default.nix");
+
+    let mut problems = Vec::new();
+    if !deb_dest.ends_with(SUFFIX) {
+        problems.push(format!(
+            "deb installs to `{deb_dest}`, expected to end with `{SUFFIX}`"
+        ));
+    }
+    if !aur.contains(SUFFIX) {
+        problems.push(format!(
+            "packaging/aur/PKGBUILD does not install to `{SUFFIX}`"
+        ));
+    }
+    if !nix.contains(SUFFIX) {
+        problems.push(format!(
+            "packaging/nix/default.nix does not install to `{SUFFIX}`"
+        ));
+    }
+
+    assert!(
+        problems.is_empty(),
+        "the PAM module install path differs between packaging formats. A PAM stack that \
+         references a path one format does not use fails closed to a password, silently.\n  {}",
+        problems.join("\n  ")
+    );
+}

--- a/crates/visaged/tests/pam_control_contract.rs
+++ b/crates/visaged/tests/pam_control_contract.rs
@@ -1,0 +1,218 @@
+//! Contract: the PAM control string is valid, and identical everywhere we ship it.
+//!
+//! This is the test for the worst bug in this project's history.
+//!
+//! From v0.1.0 to v0.3.2 the packaging shipped `[success=end default=ignore]`.
+//! `end` is not a valid PAM action. libpam does not reject an unknown keyword —
+//! it silently treats it as `ignore`, so **face authentication was a complete
+//! no-op on the documented setup path for two minor releases**, and everything
+//! looked fine: the module loaded, the daemon ran, `sudo` asked for a password
+//! and nobody could tell that was the fallback rather than a failed match.
+//!
+//! Nothing in the Rust code was wrong. The defect lived entirely in a string in
+//! a packaging file, which is why no unit test could reach it.
+//!
+//! The string is duplicated across three packaging formats with no shared
+//! constant, so it can also drift between them — a second failure mode where
+//! Debian users and NixOS users get different authentication behaviour from the
+//! same release.
+
+use std::path::{Path, PathBuf};
+
+/// Every file that declares the PAM control for `pam_visage.so`.
+const DECLARING_FILES: &[&str] = &[
+    "packaging/debian/pam-auth-update",
+    "packaging/aur/visage.install",
+    "packaging/nix/module.nix",
+];
+
+/// Valid PAM actions, per `pam.conf(5)`. Anything else — including `end` — is
+/// silently treated as `ignore` by libpam.
+const VALID_ACTIONS: &[&str] = &["ignore", "bad", "die", "ok", "done", "reset"];
+
+/// Valid tokens on the left of `=` in a `[...]` control, per `pam.conf(5)`.
+const VALID_TOKENS: &[&str] = &[
+    "default",
+    "success",
+    "open_err",
+    "symbol_err",
+    "service_err",
+    "system_err",
+    "buf_err",
+    "perm_denied",
+    "auth_err",
+    "cred_insufficient",
+    "authinfo_unavail",
+    "user_unknown",
+    "maxtries",
+    "new_authtok_reqd",
+    "acct_expired",
+    "session_err",
+    "cred_unavail",
+    "cred_expired",
+    "cred_err",
+    "no_module_data",
+    "conv_err",
+    "authtok_err",
+    "authtok_recover_err",
+    "authtok_lock_busy",
+    "authtok_disable_aging",
+    "try_again",
+    "ignore",
+    "abort",
+    "authtok_expired",
+    "module_unknown",
+    "bad_item",
+];
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/visaged should be two levels below the repo root")
+        .to_path_buf()
+}
+
+/// Every `[...]` control declared for `pam_visage.so` in a file, with its line
+/// number for a useful failure message.
+fn controls_in(rel: &str) -> Vec<(usize, String)> {
+    let path = repo_root().join(rel);
+    let body = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+
+    body.lines()
+        .enumerate()
+        .filter(|(_, line)| {
+            let t = line.trim_start();
+            // Comments never configure PAM. `#` covers shell and nix; the deb
+            // profile uses no comment syntax on its Auth lines.
+            !t.starts_with('#') && (t.contains("pam_visage.so") || t.contains("control ="))
+        })
+        .filter_map(|(i, line)| {
+            let open = line.find('[')?;
+            let close = line[open..].find(']')? + open;
+            Some((i + 1, line[open..=close].to_string()))
+        })
+        .collect()
+}
+
+/// Split `[a=b c=d]` into its `(token, action)` pairs.
+fn parse_control(control: &str) -> Vec<(String, String)> {
+    control
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .split_whitespace()
+        .filter_map(|pair| {
+            let (tok, action) = pair.split_once('=')?;
+            Some((tok.to_string(), action.to_string()))
+        })
+        .collect()
+}
+
+fn all_controls() -> Vec<(&'static str, usize, String)> {
+    DECLARING_FILES
+        .iter()
+        .flat_map(|f| {
+            controls_in(f)
+                .into_iter()
+                .map(move |(line, c)| (*f, line, c))
+        })
+        .collect()
+}
+
+#[test]
+fn every_shipped_pam_control_is_valid() {
+    let controls = all_controls();
+
+    // Vacuity guard. If extraction silently found nothing, every assertion
+    // below would pass over an empty set and this test would be decorative.
+    assert!(
+        controls.len() >= DECLARING_FILES.len(),
+        "found only {} PAM control declarations across {} packaging files — the extractor \
+         is broken, not the packaging. A pass here would mean nothing.\nfound: {controls:#?}",
+        controls.len(),
+        DECLARING_FILES.len()
+    );
+
+    let mut problems = Vec::new();
+    for (file, line, control) in &controls {
+        let pairs = parse_control(control);
+        if pairs.is_empty() {
+            problems.push(format!(
+                "{file}:{line}: `{control}` parses to no token=action pairs"
+            ));
+            continue;
+        }
+        for (tok, action) in pairs {
+            if !VALID_TOKENS.contains(&tok.as_str()) {
+                problems.push(format!(
+                    "{file}:{line}: `{tok}` is not a PAM return code (in `{control}`)"
+                ));
+            }
+            // An action is a keyword or a non-negative jump count.
+            let action_ok =
+                VALID_ACTIONS.contains(&action.as_str()) || action.parse::<u32>().is_ok();
+            if !action_ok {
+                problems.push(format!(
+                    "{file}:{line}: `{action}` is not a valid PAM action (in `{control}`). \
+                     libpam does NOT reject an unknown action — it silently treats it as \
+                     `ignore`, which makes face auth a no-op that looks like it works. \
+                     This is exactly the `success=end` bug that shipped from v0.1.0 to v0.3.2."
+                ));
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "invalid PAM control(s):\n  {}",
+        problems.join("\n  ")
+    );
+}
+
+#[test]
+fn every_shipped_pam_control_is_identical() {
+    let controls = all_controls();
+    assert!(
+        controls.len() >= DECLARING_FILES.len(),
+        "extractor found too few controls to compare — see every_shipped_pam_control_is_valid"
+    );
+
+    let (first_file, first_line, first) = &controls[0];
+    let divergent: Vec<_> = controls
+        .iter()
+        .filter(|(_, _, c)| c != first)
+        .map(|(f, l, c)| format!("{f}:{l}: `{c}`"))
+        .collect();
+
+    assert!(
+        divergent.is_empty(),
+        "packaging formats disagree on the PAM control. Debian, Arch and NixOS users would \
+         get different authentication behaviour from the same release, and there is no shared \
+         constant to keep them in step.\n  baseline {first_file}:{first_line}: `{first}`\n  {}",
+        divergent.join("\n  ")
+    );
+}
+
+/// Proves the validator would actually reject the historic bug, rather than
+/// passing because it accepts everything.
+#[test]
+fn the_validator_rejects_the_success_end_bug() {
+    let bad = parse_control("[success=end default=ignore]");
+    let end_action_rejected = bad.iter().any(|(_, a)| {
+        a == "end" && !VALID_ACTIONS.contains(&a.as_str()) && a.parse::<u32>().is_err()
+    });
+    assert!(
+        end_action_rejected,
+        "the validator accepts `success=end` — it would not have caught the v0.1.0–v0.3.2 bug, \
+         so it is not doing the job this file exists for"
+    );
+
+    // And it must still accept what we actually ship, or it is merely strict.
+    let good = parse_control("[success=done default=ignore]");
+    assert!(
+        good.iter().all(|(t, a)| VALID_TOKENS.contains(&t.as_str())
+            && (VALID_ACTIONS.contains(&a.as_str()) || a.parse::<u32>().is_ok())),
+        "the validator rejects the control we ship — it is too strict to be useful"
+    );
+}

--- a/crates/visaged/tests/systemd_hardening_contract.rs
+++ b/crates/visaged/tests/systemd_hardening_contract.rs
@@ -1,0 +1,170 @@
+//! Contract: every hardening directive we *claim* must exist in **both**
+//! packaging definitions.
+//!
+//! This closes a class that has bitten this project twice.
+//!
+//! **Issue #78.** `docs/threat-model.md` justified `MemoryDenyWriteExecute=false`
+//! — its largest documented hardening gap — by stating the daemon "has no
+//! network access, no inbound connections". No unit directive enforced that, so
+//! the compensating control for that exception did not exist. It was reported by
+//! an external contributor, not caught by us.
+//!
+//! **`TimeoutStopSec`.** Added for issue #26 to cut a ~90s post-hibernate hang
+//! to ~10s. It was present in the Debian unit and absent from the NixOS module,
+//! so on every NixOS host the fix was simply not applied — the running service
+//! reported systemd's 90s default, exactly the hang it was meant to eliminate.
+//! This test was written before that was fixed, and failed on it.
+//!
+//! Neither defect is reachable by a unit test. Both are contracts *between
+//! artifacts*: a security document and a unit file; two packaging formats that
+//! must agree and have no shared source.
+//!
+//! # Why the list is hardcoded here rather than parsed from the doc
+//!
+//! Parsing `threat-model.md` at test time would make the doc the single source
+//! and remove all possible drift — but it couples the build to prose, so a
+//! reworded table breaks CI. That is the fragility class this repo has spent
+//! real time removing. Instead the contract is stated here, in code, citing the
+//! doc. Adding a directive to the doc without adding it here is a review moment,
+//! not a silent divergence.
+
+use std::path::{Path, PathBuf};
+
+/// Hardening directives that must be present in **both** packaging definitions.
+///
+/// Source of truth for *why* each is claimed: `docs/threat-model.md`, the
+/// "systemd Sandbox" table. Keep the two in step — if you add a row there, add
+/// it here.
+const REQUIRED_DIRECTIVES: &[&str] = &[
+    "CapabilityBoundingSet",
+    "DeviceAllow",
+    "MemoryDenyWriteExecute",
+    "NoNewPrivileges",
+    // Enforces the "no network access" claim that threat-model.md relies on to
+    // justify MemoryDenyWriteExecute=false. Issue #78.
+    "PrivateNetwork",
+    "PrivateTmp",
+    "ProtectHome",
+    "ProtectSystem",
+    "ReadWritePaths",
+    "SystemCallArchitectures",
+    // Bounds a stuck v4l2 capture on stop/restart. Issue #26; without it a
+    // post-hibernate restart hangs for systemd's 90s default.
+    "TimeoutStopSec",
+];
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is <repo>/crates/visaged
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/visaged should be two levels below the repo root")
+        .to_path_buf()
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// Lines with the leading `#` comment stripped, so a directive that appears only
+/// inside a comment does not count as present.
+fn uncommented(body: &str) -> Vec<&str> {
+    body.lines()
+        .map(str::trim)
+        .filter(|l| !l.starts_with('#'))
+        .collect()
+}
+
+/// `Directive=value` — systemd unit syntax.
+fn unit_declares(body: &str, directive: &str) -> bool {
+    let prefix = format!("{directive}=");
+    uncommented(body).iter().any(|l| l.starts_with(&prefix))
+}
+
+/// `Directive = value;` — Nix attribute syntax.
+fn nix_declares(body: &str, directive: &str) -> bool {
+    let prefix = format!("{directive} =");
+    uncommented(body).iter().any(|l| l.starts_with(&prefix))
+}
+
+/// The `systemd.services.visaged` block only.
+///
+/// Scoped deliberately: the module also defines `systemd.services.visage-resume`,
+/// and a directive present only there must not count as protecting the daemon.
+fn visaged_service_block(module: &str) -> String {
+    let start = module
+        .find("systemd.services.visaged = {")
+        .expect("module.nix should define systemd.services.visaged");
+    let rest = &module[start..];
+    // The next service definition ends this block.
+    let end = rest[1..]
+        .find("systemd.services.")
+        .map(|i| i + 1)
+        .unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+#[test]
+fn every_required_directive_is_declared_in_both_packaging_definitions() {
+    let unit = read("packaging/systemd/visaged.service");
+    let module = read("packaging/nix/module.nix");
+    let block = visaged_service_block(&module);
+
+    let mut missing = Vec::new();
+    for directive in REQUIRED_DIRECTIVES {
+        if !unit_declares(&unit, directive) {
+            missing.push(format!("packaging/systemd/visaged.service: {directive}"));
+        }
+        if !nix_declares(&block, directive) {
+            missing.push(format!(
+                "packaging/nix/module.nix (systemd.services.visaged): {directive}"
+            ));
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "hardening directives claimed in docs/threat-model.md are missing from a packaging \
+         definition. A directive present in one format and absent from the other means the \
+         protection silently does not apply on that platform — this is issue #78's class.\n  {}",
+        missing.join("\n  ")
+    );
+}
+
+/// A control for the test above.
+///
+/// If the extraction or matching breaks, `every_required_directive_...` would
+/// pass vacuously on an empty search space. This proves the instrument can see
+/// a directive at all, and that scoping to the visaged block actually excludes
+/// the sibling service.
+#[test]
+fn the_matchers_can_see_a_directive_and_the_scoping_excludes_the_sibling_service() {
+    let unit = read("packaging/systemd/visaged.service");
+    let module = read("packaging/nix/module.nix");
+    let block = visaged_service_block(&module);
+
+    // Positive control: ExecStart is unmissable in both.
+    assert!(
+        unit_declares(&unit, "ExecStart"),
+        "positive control failed — the unit matcher cannot see ExecStart, so an empty \
+         result from it means nothing"
+    );
+    assert!(
+        nix_declares(&block, "ExecStart"),
+        "positive control failed — the nix matcher cannot see ExecStart"
+    );
+
+    // Negative control: a directive that exists in neither file must read absent.
+    assert!(
+        !unit_declares(&unit, "ThisDirectiveDoesNotExist"),
+        "negative control failed — the unit matcher reports a fabricated directive as present"
+    );
+
+    // Scoping control: the block must stop before the sibling service.
+    assert!(
+        !block.contains("systemd.services.visage-resume"),
+        "scoping failed — the extracted visaged block ran on into visage-resume, so a \
+         directive present only on the sibling would be miscounted as protecting the daemon"
+    );
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -174,14 +174,54 @@ Items marked ✅ have been verified; items marked ⬜ require hardware not avail
 
 ## Test Coverage Summary
 
+### Unit tests
+
 | Crate | Tests | What they cover |
 |-------|-------|----------------|
-| `pam-visage` | 5 | PAM/syslog constant values, D-Bus error handling without daemon |
+| `pam-visage` | 8 | PAM/syslog constant values, timeout argument parsing, D-Bus error handling without daemon |
 | `visage-core` | 38 | Detection, alignment, recognition preprocessing, matching, liveness landmark stability |
-| `visage-hw` | 9 | Frame processing, CLAHE, dark frame detection, pixel conversion |
+| `visage-hw` | 13 | Frame processing, CLAHE, dark frame detection, pixel conversion, hardware quirk DB |
 | `visage-models` | 4 | SHA-256 verification: missing file, checksum mismatch, checksum match, missing directory |
-| `visaged` | 14 | Rate limiting, store roundtrip, encryption, corruption hardening |
-| **Total** | **70** | **Unit tests — no integration tests; no hardware tests** |
+| `visaged` | 18 | Rate limiting, store roundtrip, encryption, corruption hardening, session-bus config |
+| **Subtotal** | **81** | |
 
-Integration tests (camera + inference + daemon + PAM) are not present. They require physical
-hardware (IR camera) and are deferred to manual acceptance testing on Ubuntu 24.04.
+### Integration tests
+
+Added 2026-08-24, in `crates/visaged/tests/`. These exist because **both of the worst bugs in
+this project's history were structurally invisible to unit tests** — `success=end` (an invalid
+PAM keyword libpam silently treated as `ignore`, making face auth a no-op from v0.1.0 to
+v0.3.2) and the V4L2 format cache (#48). Neither was a logic error in a function; both were
+contracts *between artifacts*.
+
+| Test | Tests | What it guards |
+|------|-------|----------------|
+| `pam_control_contract` | 3 | The PAM control string is a valid libpam control, and identical across the Debian, Arch and NixOS packaging. Directly targets the `success=end` class. |
+| `systemd_hardening_contract` | 2 | Every hardening directive `threat-model.md` claims exists in **both** systemd definitions. Targets the #78 class — a documented control nothing enforced. |
+| `packaging_paths_contract` | 4 | Deb assets name real build targets, shipped source files exist, `ExecStart` matches the install path, PAM module path agrees across formats. |
+| `dbus_contract` | 3 | The interface the daemon serves is the one its three independently-compiled clients call. |
+| **Subtotal** | **12** | **Hermetic — no hardware, no root, no D-Bus, no models, no new dependencies** |
+
+**Total: 93 running tests**, plus 3 ignored.
+
+### Hardware tests
+
+`daemon_lifecycle` (3 tests, `#[ignore]`) launches the real daemon on a private session bus and
+drives it over D-Bus — bus-name registration, `Status`, `Verify` on an unenrolled user, and the
+property that matters most for PAM: that a client call **fails promptly rather than hanging**
+once the daemon is gone.
+
+`spawn_engine` opens the camera before serving D-Bus, so there is no headless path. Run on a
+machine with an IR camera:
+
+```bash
+cargo test -p visaged --test daemon_lifecycle -- --ignored --nocapture
+# VISAGE_TEST_CAMERA   (default /dev/video2)
+# VISAGE_TEST_MODEL_DIR (default /var/lib/visage/models)
+```
+
+⚠️ Stop a running production `visaged` first — it holds the capture device, so the test daemon
+cannot open it while that is live.
+
+Still absent: an end-to-end **recognition** test (enrol a face, verify it matches), which needs a
+face in front of the camera and is inherently interactive; and a NixOS VM test exercising the
+real PAM stack via `pamtester`.

--- a/packaging/nix/module.nix
+++ b/packaging/nix/module.nix
@@ -289,6 +289,17 @@ in
         Restart = "on-failure";
         RestartSec = 5;
 
+        # Bounds a stuck v4l2 capture on `systemctl stop|restart`. visaged
+        # handles SIGINT/SIGTERM at the runtime layer (issue #26); this covers
+        # the case where a capture is mid-flight and not promptly interruptible,
+        # e.g. after hibernate resume with a stale camera fd.
+        #
+        # This mirrors packaging/systemd/visaged.service, which has carried it
+        # since #26. It was missing here, so NixOS hosts fell back to systemd's
+        # 90s default — precisely the hang the fix removed on Debian. Found by
+        # tests/systemd_hardening_contract.rs.
+        TimeoutStopSec = 10;
+
         # Hardening (mirrors packaging/systemd/visaged.service)
         NoNewPrivileges = true;
         ProtectSystem = "strict";


### PR DESCRIPTION
`docs/STATUS.md` said it plainly: *"Integration tests (camera + inference + daemon + PAM) are not present."* Confirmed — **zero** `crates/*/tests/` directories, no dev-dependencies anywhere, all 81 tests in-module units.

## Why this class specifically

**Both of the worst bugs in this project's history were structurally invisible to unit tests.**

- **`success=end`** — an invalid PAM control keyword. libpam does not reject an unknown action; it silently treats it as `ignore`. Face auth was a **complete no-op on the documented setup path from v0.1.0 to v0.3.2**, across two minor releases, and everything looked fine.
- **The V4L2 format cache** (#48) — the daemon cached its format at open and never re-asserted it, decoding garbage until a manual restart.

Neither is a logic error in a function. Both are **contracts between artifacts**: a packaging file and libpam; a daemon and a device it does not own. Issue #78 was a third instance — `threat-model.md` justified its largest hardening gap with a network-isolation claim no unit directive enforced.

## The four hermetic tests

| test | guards |
|---|---|
| `pam_control_contract` (3) | the control string is a **valid** libpam control **and** identical across Debian/Arch/NixOS packaging — it rejects `success=end` by name |
| `systemd_hardening_contract` (2) | every directive `threat-model.md` claims exists in **both** systemd definitions — #78 generalised |
| `packaging_paths_contract` (4) | the deb ships artifacts the workspace builds, shipped files exist, `ExecStart` matches the install path, PAM path agrees across formats |
| `dbus_contract` (3) | the interface the daemon serves is the one its **three independently-compiled** clients call |

No hardware, no root, no D-Bus, no models, **no new dependencies**, no workflow changes — CI already runs `cargo test --workspace`.

## What the first guard found

⚠️ **`TimeoutStopSec` was missing from `packaging/nix/module.nix`.** `systemd_hardening_contract` **failed on the tree as it stood**, naming it.

That directive was added for #26 to bound a stuck v4l2 capture on `systemctl stop|restart`, cutting a ~90s post-hibernate hang to ~10s. It existed **only in the Debian unit**, so NixOS hosts never received the fix — a running host reports `TimeoutStopUSec=1min 30s`, systemd's default, which is precisely the hang it was meant to remove. Fixed here.

Same class as #78, found by the guard written for that class, before merge.

## Hardware tier

`daemon_lifecycle` (3, `#[ignore]`) launches the real daemon on a private session bus and drives it over D-Bus. `spawn_engine` opens the camera before serving D-Bus, so there is no headless path — rather than depend on a virtual V4L2 device in CI (another externally-maintained thing that can silently break the build, which is what we spent this week removing), it runs on real hardware:

```bash
cargo test -p visaged --test daemon_lifecycle -- --ignored --nocapture
```

Its most important assertion is that a client call **fails promptly once the daemon is gone**. `pam-visage`'s entire contract is that it never blocks a login; a hang there is an unbootable machine, and nothing else exercises it.

## Every guard proven to fail

Each was made to fail on the defect it exists for, then restored from a snapshot and re-verified green:

| injected | result |
|---|---|
| `success=end` | `pam_control_contract` fails on **validity** |
| a valid-but-different control | fails on **identity only** — discriminating |
| a server method renamed | `dbus_contract` names **both** affected clients |
| a `[[bin]]` renamed | `packaging_paths_contract` names the artifact |
| a shipped file removed | `packaging_paths_contract` names the file |
| `TimeoutStopSec` absent | `systemd_hardening_contract`, **before the fix** |

Each file also carries its own **control test**, so a broken extractor cannot pass vacuously over an empty set.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- **93 tests pass, 0 failures, 3 ignored** (was 81).
- The lifecycle fixture smoke-tested against a deliberately nonexistent camera: fails in **10.4s with its own diagnostic** rather than hanging, and its `Drop` reaps both child processes and the temp directory — verified by process count afterwards.

**Not run:** `daemon_lifecycle` against the real camera. The production `visaged` holds the capture device, and taking that away would disturb a live authentication daemon. The fixture is verified up to that boundary.

`docs/STATUS.md` also had a stale count (said 70; actual 81 unit) — corrected from measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
