### PR TITLE
chore(release): 0.4.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0-rc.1 — 2026-08-24
+
 ### Added
 
 - **`visage onboard` — one command from nothing to working face auth.** Downloads

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "pam-visage"
-version = "0.3.6"
+version = "0.4.0-rc.1"
 dependencies = [
  "libc",
  "zbus",
@@ -2651,7 +2651,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visage-cli"
-version = "0.3.6"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "visage-core"
-version = "0.3.6"
+version = "0.4.0-rc.1"
 dependencies = [
  "image",
  "ndarray",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "visage-hw"
-version = "0.3.6"
+version = "0.4.0-rc.1"
 dependencies = [
  "libc",
  "serde",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "visage-models"
-version = "0.3.6"
+version = "0.4.0-rc.1"
 dependencies = [
  "sha2",
  "thiserror",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "visaged"
-version = "0.3.6"
+version = "0.4.0-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.6"
+version = "0.4.0-rc.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sovren-software/visage"


### PR DESCRIPTION
First release since **v0.3.6 on 2026-07-07** — 47 days and 36 commits, **none of which reached a user**, because the release pipeline had been silently inert since v0.3.4 (#75).

## Why 0.4.0 and not 0.3.7

The delta adds public surface: `visage onboard`, a `timeout=N` argument to `pam_visage.so`, and five new NixOS options. Under SemVer 0.x a new backward-compatible feature is a **minor** bump. A patch version would claim no new API, which is false here — and the version number is how consumers decide whether to read the changelog.

## Why an rc first

The rewritten release pipeline has **never run in this form**. The first tag push *is* its first real test, and doing that as a pre-release is strictly lower risk than doing it as "Latest". It also exercises the semver-derived `prerelease` branch added in #86.

## Contents

Six PRs merged this session, plus the 30 commits that were already stranded:

| | |
|---|---|
| **#87** | clippy 1.98 lint without raising MSRV — unblocked a base that had been red for 6 days |
| **#86** | release job tag-triggered; refuses to publish an assetless release |
| **#88** | `PrivateNetwork=true` — closed #78, a documented control nothing enforced |
| **#89** | toolchain pinned to the devshell version + non-blocking `clippy-latest` |
| **#90** | liveness verdicts reconciled with what hardware measured |
| **#91** | the first integration tests — and `TimeoutStopSec`, which the first guard found |

Plus, from the stranded backlog: the `bindgenHook` fix that closes **#69**, `visage onboard`, the first externally contributed hardware quirk (**#76**), and ten dependency bumps.

## Purely mechanical

Version bump, CHANGELOG header rename, lock regeneration. **Three files, no code changes**, per the project's release-PR discipline.

## Verified against this tree

- The release job's **tag-vs-manifest assertion matches** (`0.4.0-rc.1`), and `prerelease` derives `true`.
- The changelog extraction yields **248 non-empty lines** and stops before `v0.3.6`.
- `fmt` clean, `clippy --workspace --all-targets -D warnings` clean, **93 tests pass, 0 failures**.

**Not verified, by construction:** that the pipeline works end to end. Only the tag push tests that, which is the point of cutting an rc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)